### PR TITLE
Deprecate :action_blacklist option

### DIFF
--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -214,6 +214,9 @@ module TraceView
         @@config[key.to_sym] = value.to_i
         TraceView.set_sample_rate(value) if TraceView.loaded
 
+      elsif key == :action_blacklist
+        TraceView.logger.warn "[traceview/deprecation] :action_blacklist will be deprecated in a future version."
+
       elsif key == :include_url_query_params
         # Obey the global flag and update all of the per instrumentation
         # <tt>:log_args</tt> values.


### PR DESCRIPTION
We're going to eventually remove `TraceView::Config[:action_blacklist]` since it was very rarely used. So let's preemptively add a deprecation notice first.