### PR TITLE
Add a way to restart the reporter easily

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,7 @@ Rake::TestTask.new do |t|
     t.test_files = FileList['test/frameworks/sinatra*_test.rb']
   when /libraries/
     t.test_files = FileList['test/support/*_test.rb'] +
+                   FileList['test/reporter/*_test.rb'] +
                    FileList['test/instrumentation/*_test.rb'] +
                    FileList['test/profiling/*_test.rb']
   end

--- a/lib/joboe_metal.rb
+++ b/lib/joboe_metal.rb
@@ -44,83 +44,96 @@ module Oboe_metal
   end
 
   module Reporter
-    ##
-    # Initialize the TraceView Context, reporter and report the initialization
-    #
-    def self.start
-      return unless TraceView.loaded
+    class << self
+      ##
+      # start
+      #
+      # Start the TraceView Reporter
+      #
+      def start
+        return unless TraceView.loaded
 
-      if ENV.key?('TRACEVIEW_GEM_TEST')
-        TraceView.reporter = Java::ComTracelyticsJoboe::TestReporter.new
-      else
-        TraceView.reporter = Java::ComTracelyticsJoboe::ReporterFactory.getInstance.buildUdpReporter
-      end
-
-
-      begin
-        # Import the tracing mode and sample rate settings
-        # from the Java agent (user configured in
-        # /usr/local/tracelytics/javaagent.json when under JRuby)
-        cfg = LayerUtil.getLocalSampleRate(nil, nil)
-
-        if cfg.hasSampleStartFlag
-          TraceView::Config.tracing_mode = 'always'
-        elsif cfg.hasSampleThroughFlag
-          TraceView::Config.tracing_mode = 'through'
+        if ENV.key?('TRACEVIEW_GEM_TEST')
+          TraceView.reporter = Java::ComTracelyticsJoboe::TestReporter.new
         else
-          TraceView::Config.tracing_mode = 'never'
+          TraceView.reporter = Java::ComTracelyticsJoboe::ReporterFactory.getInstance.buildUdpReporter
         end
 
-        TraceView.sample_rate = cfg.getSampleRate
-        TraceView::Config.sample_rate = cfg.sampleRate
-        TraceView::Config.sample_source = cfg.sampleRateSourceValue
-      rescue => e
-        TraceView.logger.debug "[traceview/debug] Couldn't retrieve/acces joboe sampleRateCfg"
-        TraceView.logger.debug "[traceview/debug] #{e.message}"
+        begin
+          # Import the tracing mode and sample rate settings
+          # from the Java agent (user configured in
+          # /usr/local/tracelytics/javaagent.json when under JRuby)
+          cfg = LayerUtil.getLocalSampleRate(nil, nil)
+
+          if cfg.hasSampleStartFlag
+            TraceView::Config.tracing_mode = 'always'
+          elsif cfg.hasSampleThroughFlag
+            TraceView::Config.tracing_mode = 'through'
+          else
+            TraceView::Config.tracing_mode = 'never'
+          end
+
+          TraceView.sample_rate = cfg.getSampleRate
+          TraceView::Config.sample_rate = cfg.sampleRate
+          TraceView::Config.sample_source = cfg.sampleRateSourceValue
+        rescue => e
+          TraceView.logger.debug "[traceview/debug] Couldn't retrieve/acces joboe sampleRateCfg"
+          TraceView.logger.debug "[traceview/debug] #{e.message}"
+        end
+
+        # Only report __Init from here if we are not instrumenting a framework.
+        # Otherwise, frameworks will handle reporting __Init after full initialization
+        unless defined?(::Rails) || defined?(::Sinatra) || defined?(::Padrino) || defined?(::Grape)
+          TraceView::API.report_init unless ENV.key?('TRACEVIEW_GEM_TEST')
+        end
       end
 
-      # Only report __Init from here if we are not instrumenting a framework.
-      # Otherwise, frameworks will handle reporting __Init after full initialization
-      unless defined?(::Rails) || defined?(::Sinatra) || defined?(::Padrino) || defined?(::Grape)
-        TraceView::API.report_init unless ENV.key?('TRACEVIEW_GEM_TEST')
+      ##
+      # restart
+      #
+      # This is a nil method for TraceView under Java.  It is maintained only
+      # for compability across interfaces.
+      #
+      def restart
+        TraceView.logger.warn "[traceview/reporter] Reporter.restart isn't supported under JRuby"
       end
-    end
 
-    ##
-    # clear_all_traces
-    #
-    # Truncates the trace output file to zero
-    #
-    def self.clear_all_traces
-      TraceView.reporter.reset if TraceView.loaded
-    end
-
-    ##
-    # get_all_traces
-    #
-    # Retrieves all traces written to the trace file
-    #
-    def self.get_all_traces
-      return [] unless TraceView.loaded
-
-      # Joboe TestReporter returns a Java::ComTracelyticsExtEbson::DefaultDocument
-      # document for traces which doesn't correctly support things like has_key? which
-      # raises an unhandled exception on non-existent key (duh).  Here we convert
-      # the Java::ComTracelyticsExtEbson::DefaultDocument doc to a pure array of Ruby
-      # hashes
-      traces = []
-      TraceView.reporter.getSentEventsAsBsonDocument.to_a.each do |e|
-        t = {}
-        e.each_pair { |k, v|
-          t[k] = v
-        }
-        traces << t
+      ##
+      # clear_all_traces
+      #
+      # Truncates the trace output file to zero
+      #
+      def clear_all_traces
+        TraceView.reporter.reset if TraceView.loaded
       end
-      traces
-    end
 
-    def self.sendReport(evt)
-      evt.report(TraceView.reporter)
+      ##
+      # get_all_traces
+      #
+      # Retrieves all traces written to the trace file
+      #
+      def get_all_traces
+        return [] unless TraceView.loaded
+
+        # Joboe TestReporter returns a Java::ComTracelyticsExtEbson::DefaultDocument
+        # document for traces which doesn't correctly support things like has_key? which
+        # raises an unhandled exception on non-existent key (duh).  Here we convert
+        # the Java::ComTracelyticsExtEbson::DefaultDocument doc to a pure array of Ruby
+        # hashes
+        traces = []
+        TraceView.reporter.getSentEventsAsBsonDocument.to_a.each do |e|
+          t = {}
+          e.each_pair { |k, v|
+            t[k] = v
+          }
+          traces << t
+        end
+        traces
+      end
+
+      def sendReport(evt)
+        evt.report(TraceView.reporter)
+      end
     end
   end
 end

--- a/lib/oboe_metal.rb
+++ b/lib/oboe_metal.rb
@@ -12,8 +12,11 @@ module TraceView
 
   class Reporter
     class << self
+
       ##
-      # Initialize the TraceView Context, reporter and report the initialization
+      # start
+      #
+      # Start the TraceView Reporter
       #
       def start
         return unless TraceView.loaded
@@ -40,6 +43,11 @@ module TraceView
       end
       alias :restart :start
 
+      ##
+      # sendReport
+      #
+      # Send the report for the given event
+      #
       def sendReport(evt)
         TraceView.reporter.sendReport(evt)
       end

--- a/lib/oboe_metal.rb
+++ b/lib/oboe_metal.rb
@@ -38,10 +38,7 @@ module TraceView
           raise
         end
       end
-
-      def restart
-
-      end
+      alias :restart :start
 
       def sendReport(evt)
         TraceView.reporter.sendReport(evt)

--- a/lib/oboe_metal.rb
+++ b/lib/oboe_metal.rb
@@ -11,70 +11,76 @@ module TraceView
   include Oboe_metal
 
   class Reporter
-    ##
-    # Initialize the TraceView Context, reporter and report the initialization
-    #
-    def self.start
-      return unless TraceView.loaded
+    class << self
+      ##
+      # Initialize the TraceView Context, reporter and report the initialization
+      #
+      def start
+        return unless TraceView.loaded
 
-      begin
-        Oboe_metal::Context.init
+        begin
+          Oboe_metal::Context.init
 
-        if ENV.key?('TRACEVIEW_GEM_TEST')
-          TraceView.reporter = TraceView::FileReporter.new('/tmp/trace_output.bson')
-        else
-          TraceView.reporter = TraceView::UdpReporter.new(TraceView::Config[:reporter_host], TraceView::Config[:reporter_port])
-        end
+          if ENV.key?('TRACEVIEW_GEM_TEST')
+            TraceView.reporter = TraceView::FileReporter.new('/tmp/trace_output.bson')
+          else
+            TraceView.reporter = TraceView::UdpReporter.new(TraceView::Config[:reporter_host], TraceView::Config[:reporter_port])
+          end
 
-        # Only report __Init from here if we are not instrumenting a framework.
-        # Otherwise, frameworks will handle reporting __Init after full initialization
-        unless defined?(::Rails) || defined?(::Sinatra) || defined?(::Padrino) || defined?(::Grape)
-          TraceView::API.report_init unless ENV.key?('TRACEVIEW_GEM_TEST')
-        end
+          # Only report __Init from here if we are not instrumenting a framework.
+          # Otherwise, frameworks will handle reporting __Init after full initialization
+          unless defined?(::Rails) || defined?(::Sinatra) || defined?(::Padrino) || defined?(::Grape)
+            TraceView::API.report_init
+          end
 
-      rescue => e
-        $stderr.puts e.message
-        raise
-      end
-    end
-
-    def self.sendReport(evt)
-      TraceView.reporter.sendReport(evt)
-    end
-
-    ##
-    # clear_all_traces
-    #
-    # Truncates the trace output file to zero
-    #
-    def self.clear_all_traces
-      File.truncate($trace_file, 0)
-    end
-
-    ##
-    # get_all_traces
-    #
-    # Retrieves all traces written to the trace file
-    #
-    def self.get_all_traces
-      io = File.open($trace_file, 'r')
-      contents = io.readlines(nil)
-
-      return contents if contents.empty?
-
-      s = StringIO.new(contents[0])
-
-      traces = []
-
-      until s.eof?
-        if ::BSON.respond_to? :read_bson_document
-          traces << BSON.read_bson_document(s)
-        else
-          traces << BSON::Document.from_bson(s)
+        rescue => e
+          $stderr.puts e.message
+          raise
         end
       end
 
-      traces
+      def restart
+
+      end
+
+      def sendReport(evt)
+        TraceView.reporter.sendReport(evt)
+      end
+
+      ##
+      # clear_all_traces
+      #
+      # Truncates the trace output file to zero
+      #
+      def clear_all_traces
+        File.truncate($trace_file, 0)
+      end
+
+      ##
+      # get_all_traces
+      #
+      # Retrieves all traces written to the trace file
+      #
+      def get_all_traces
+        io = File.open($trace_file, 'r')
+        contents = io.readlines(nil)
+
+        return contents if contents.empty?
+
+        s = StringIO.new(contents[0])
+
+        traces = []
+
+        until s.eof?
+          if ::BSON.respond_to? :read_bson_document
+            traces << BSON.read_bson_document(s)
+          else
+            traces << BSON::Document.from_bson(s)
+          end
+        end
+
+        traces
+      end
     end
   end
 

--- a/lib/traceview/api/layerinit.rb
+++ b/lib/traceview/api/layerinit.rb
@@ -11,11 +11,13 @@ module TraceView
       # layer.
       #
       def report_init(layer = 'rack')
-        # Don't send __Init in development or test
-        return if %w(development test).include? ENV['RACK_ENV']
-
-        # Don't send __Init if the c-extension hasn't loaded
-        return unless TraceView.loaded
+        # Don't send __Init in development, test or if the gem
+        # isn't fully loaded (e.g. missing c-extension)
+        if %w(development test).include? ENV['RACK_ENV'] ||
+                          ENV.key?('TRACEVIEW_GEM_TEST') ||
+                          !TraceView.loaded
+          return
+        end
 
         platform_info = TraceView::Util.build_init_report
 

--- a/test/reporter/reporter_test.rb
+++ b/test/reporter/reporter_test.rb
@@ -1,0 +1,14 @@
+# Copyright (c) 2015 AppNeta, Inc.
+# All rights reserved.
+
+require 'minitest_helper'
+
+class TVReporterTest < Minitest::Test
+  def reporter_has_start_method
+    assert_equal true, TV::Reporter.respond_to?(:start), "has restart method"
+  end
+
+  def reporter_has_restart_method
+    assert_equal true, TV::Reporter.respond_to?(:restart), "has start method"
+  end
+end

--- a/test/servers/sidekiq.rb
+++ b/test/servers/sidekiq.rb
@@ -28,7 +28,7 @@ sleep 10
 
 # Add a hook to shutdown sidekiq after Minitest finished running
 Minitest.after_run {
-  TraceView.logger.warn "[traceview/servers] Shutting down Sidekiq. (pid: #{@sidekiq_pid})"
+  TraceView.logger.warn "[traceview/servers] Shutting down Sidekiq."
   pid = File.read("/tmp/sidekiq_#{Process.pid}.pid").chomp
   Process.kill(:TERM, pid.to_i)
   File.unlink "/tmp/sidekiq_#{Process.pid}.pid"


### PR DESCRIPTION
If a user has to reconfigure the TraceView reporter, it has to be restarted to take the new config.  We should add a method to do this easily.