### PR TITLE
We should require Set before referencing it 

### DIFF
--- a/lib/traceview/api/logging.rb
+++ b/lib/traceview/api/logging.rb
@@ -1,6 +1,13 @@
 # Copyright (c) 2013 AppNeta, Inc.
 # All rights reserved.
 
+# Make sure Set is loaded if possible.
+begin
+  require 'set'
+rescue LoadError
+  class Set; end
+end
+
 module TraceView
   module API
     ##

--- a/test/support/liboboe_settings_test.rb
+++ b/test/support/liboboe_settings_test.rb
@@ -1,6 +1,7 @@
 # Copyright (c) 2015 AppNeta, Inc.
 # All rights reserved.
 
+require 'set'
 require 'minitest_helper'
 require 'rack/test'
 require 'rack/lobster'


### PR DESCRIPTION
Although it doesn't happen consistently, in some environments Set is an undefined variable unless we explicitly call `require 'set'`.  We should do this in `lib/traceview/api/logging.rb` (where Set is referenced).