### PR TITLE
Remove :action_blacklist

### DIFF
--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -217,7 +217,7 @@ module TraceView
         TraceView.set_sample_rate(value) if TraceView.loaded
 
       elsif key == :action_blacklist
-        TraceView.logger.warn "[traceview/deprecation] :action_blacklist will be deprecated in a future version."
+        TraceView.logger.warn "[traceview/unsupported] :action_blacklist has been deprecated and no longer functions."
 
       elsif key == :include_url_query_params
         # Obey the global flag and update all of the per instrumentation

--- a/lib/traceview/frameworks/rails/inst/action_controller.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller.rb
@@ -89,7 +89,7 @@ module TraceView
 
       def process_with_traceview(*args)
         TraceView::API.log_entry('rails')
-        process_without_traceview *args
+        process_without_traceview(*args)
 
       rescue Exception => e
         TraceView::API.log_exception(nil, e) if log_rails_error?(e)
@@ -105,7 +105,7 @@ module TraceView
         }
         TraceView::API.log(nil, 'info', report_kvs)
 
-        process_action_without_traceview *args
+        process_action_without_traceview(*args)
       rescue Exception
         report_kvs[:Status] = 500
         TraceView::API.log(nil, 'info', report_kvs)
@@ -130,9 +130,6 @@ module TraceView
       end
 
       def process_action_with_traceview(method_name, *args)
-        return process_action_without_traceview(method_name, *args) if TraceView::Config[:action_blacklist].present? &&
-          TraceView::Config[:action_blacklist][[self.controller_name, self.action_name].join('#')]
-
         report_kvs = {
           :Controller   => self.class.name,
           :Action       => self.action_name,


### PR DESCRIPTION
`TraceView::Config[:action_blacklist]` is rarely used.  We are dropping support for it.  In gem version 3.3.0 we added a deprecation warning previously.