### PR TITLE
Sidekiq updates + tweaks

### DIFF
--- a/lib/traceview/inst/sidekiq-client.rb
+++ b/lib/traceview/inst/sidekiq-client.rb
@@ -24,8 +24,6 @@ module TraceView
 
     def call(*args)
       # args: 0: worker_class, 1: msg, 2: queue, 3: redis_pool
-
-      result = nil
       report_kvs = collect_kvs(args)
 
       TraceView::API.log_entry('sidekiq-client', report_kvs)
@@ -33,7 +31,7 @@ module TraceView
 
       result = yield
 
-      report_kvs = { :JobID => result["jid"] }
+      report_kvs = { :JobID => result['jid'] }
       result
     rescue => e
       TraceView::API.log_exception('sidekiq-client', e, report_kvs)

--- a/lib/traceview/inst/sidekiq-client.rb
+++ b/lib/traceview/inst/sidekiq-client.rb
@@ -29,7 +29,7 @@ module TraceView
       report_kvs = collect_kvs(args)
 
       TraceView::API.log_entry('sidekiq-client', report_kvs)
-      args[1]['X-Trace'] = TraceView::Context.toString if TraceView.tracing?
+      args[1]['SourceTrace'] = TraceView::Context.toString if TraceView.tracing?
 
       result = yield
 

--- a/lib/traceview/inst/sidekiq-worker.rb
+++ b/lib/traceview/inst/sidekiq-worker.rb
@@ -36,11 +36,10 @@ module TraceView
       # Continue the trace from the enqueue side?
       incoming_context = nil
       if args[1].is_a?(Hash) && TraceView::XTrace.valid?(args[1]['SourceTrace'])
-        incoming_context = args[1]['SourceTrace']
-        report_kvs[:Async] = true
+        report_kvs[:SourceTrace] = args[1]['SourceTrace']
       end
 
-      result = TraceView::API.start_trace('sidekiq-worker', incoming_context, report_kvs) do
+      result = TraceView::API.start_trace('sidekiq-worker', nil, report_kvs) do
         yield
       end
 

--- a/lib/traceview/inst/sidekiq-worker.rb
+++ b/lib/traceview/inst/sidekiq-worker.rb
@@ -35,8 +35,8 @@ module TraceView
 
       # Continue the trace from the enqueue side?
       incoming_context = nil
-      if args[1].is_a?(Hash) && TraceView::XTrace.valid?(args[1]['X-Trace'])
-        incoming_context = args[1]['X-Trace']
+      if args[1].is_a?(Hash) && TraceView::XTrace.valid?(args[1]['SourceTrace'])
+        incoming_context = args[1]['SourceTrace']
         report_kvs[:Async] = true
       end
 

--- a/lib/traceview/inst/sidekiq-worker.rb
+++ b/lib/traceview/inst/sidekiq-worker.rb
@@ -21,7 +21,7 @@ module TraceView
         report_kvs['HTTP-Host'] = Socket.gethostname
         report_kvs[:Controller] = "Sidekiq_#{queue}"
         report_kvs[:Action] = msg['class']
-        report_kvs[:URL] = "/sidekiq/#{queue}/#{msg['class'].to_s}"
+        report_kvs[:URL] = "/sidekiq/#{queue}/#{msg['class']}"
       rescue => e
         TraceView.logger.warn "[traceview/sidekiq] Non-fatal error capturing KVs: #{e.message}"
       end
@@ -30,7 +30,6 @@ module TraceView
 
     def call(*args)
       # args: 0: worker, 1: msg, 2: queue
-      result = nil
       report_kvs = collect_kvs(args)
 
       # Continue the trace from the enqueue side?


### PR DESCRIPTION
The recently release sidekiq instrumentation has a few minor issues:

- [x] We shouldn't carry/pickup context between client and worker traces
- [x] The passed KV should be `SourceTrace` instead of `X-Trace`