### PR TITLE
New BSON v4 gem data reporting

### DIFF
--- a/gemfiles/frameworks.gemfile
+++ b/gemfiles/frameworks.gemfile
@@ -33,7 +33,7 @@ else
   gem 'sinatra'
 end
 
-gem "grape"
+gem "grape", "< 0.14"
 gem "padrino", '< 0.13'
 
 gemspec :path => File.expand_path(File.dirname(__FILE__) + '/../')

--- a/traceview.gemspec
+++ b/traceview.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.extensions = ['ext/oboe_metal/extconf.rb'] unless defined?(JRUBY_VERSION)
 
   s.add_runtime_dependency('json', '>= 0')
+  s.add_runtime_dependency('bson', '~> 3.0')
   s.add_development_dependency('rake', '>= 0')
 
   s.required_ruby_version = '>= 1.8.6'

--- a/traceview.gemspec
+++ b/traceview.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.extensions = ['ext/oboe_metal/extconf.rb'] unless defined?(JRUBY_VERSION)
 
   s.add_runtime_dependency('json', '>= 0')
-  s.add_runtime_dependency('bson', '~> 3.0')
+  s.add_runtime_dependency('bson', '< 4.0')
   s.add_development_dependency('rake', '>= 0')
 
   s.required_ruby_version = '>= 1.8.6'


### PR DESCRIPTION
The new [v4 bson gem](https://rubygems.org/gems/bson/versions/4.0.0) throws an error when importing a BSON document.  Until we figure out the root cause (or possibly a deprecation), we will lock our bson dependency to v3.