### PR TITLE
New Grape release 0.14 breaks instrumentation

### DIFF
--- a/gemfiles/frameworks.gemfile
+++ b/gemfiles/frameworks.gemfile
@@ -32,7 +32,7 @@ else
   gem 'sinatra'
 end
 
-gem "grape", "< 0.14"
+gem "grape"
 gem "padrino", '< 0.13'
 
 gemspec :path => File.expand_path(File.dirname(__FILE__) + '/../')

--- a/gemfiles/frameworks.gemfile
+++ b/gemfiles/frameworks.gemfile
@@ -33,7 +33,14 @@ else
 end
 
 gem "grape"
-gem "padrino"
+
+if defined?(JRUBY_VERSION)
+  # Limit padrino gem under JRuby as version 0.13.0 throws
+  # a bundler load error
+  gem "padrino", '< 0.13.0'
+else
+  gem 'padrino'
+end
 
 gemspec :path => File.expand_path(File.dirname(__FILE__) + '/../')
 # vim:syntax=ruby

--- a/gemfiles/frameworks.gemfile
+++ b/gemfiles/frameworks.gemfile
@@ -33,7 +33,7 @@ else
 end
 
 gem "grape"
-gem "padrino", '< 0.13'
+gem "padrino"
 
 gemspec :path => File.expand_path(File.dirname(__FILE__) + '/../')
 # vim:syntax=ruby

--- a/lib/traceview/frameworks/grape.rb
+++ b/lib/traceview/frameworks/grape.rb
@@ -20,12 +20,17 @@ module TraceView
         ::TraceView::Util.method_alias(klass, :run, ::Grape::Endpoint)
       end
 
-      def run_with_traceview(env)
+      def run_with_traceview(*args)
         if TraceView.tracing?
           report_kvs = {}
 
           report_kvs[:Controller] = self.class
-          report_kvs[:Action] = env['PATH_INFO']
+
+          if args.empty?
+            report_kvs[:Action] = env['PATH_INFO']
+          else
+            report_kvs[:Action] = args[0]['PATH_INFO']
+          end
 
           # Fall back to the raw tracing API so we can pass KVs
           # back on exit (a limitation of the TraceView::API.trace
@@ -34,12 +39,12 @@ module TraceView
           ::TraceView::API.log_entry('grape', {})
 
           begin
-            run_without_traceview(env)
+            run_without_traceview(*args)
           ensure
             ::TraceView::API.log_exit('grape', report_kvs)
           end
         else
-          run_without_traceview(env)
+          run_without_traceview(*args)
         end
       end
     end

--- a/test/frameworks/apps/padrino_simple.rb
+++ b/test/frameworks/apps/padrino_simple.rb
@@ -9,7 +9,7 @@ PADRINO_ROOT = File.dirname(__FILE__) unless defined? PADRINO_ROOT
 
 class SimpleDemo < Padrino::Application
   set :public_folder, File.dirname(__FILE__)
-  set :reload, true
+  set :reload, false
   before { true }
   after  { true }
   error(404) { "404" }

--- a/test/models/widget.rb
+++ b/test/models/widget.rb
@@ -1,19 +1,24 @@
-class Widget < ActiveRecord::Base
-  def do_work(*args)
-    Widget.first
+# Somehow the Padrino::Reloader v14 is detecting and loading
+# this file when it shouldn't.  Block it from loading for
+# Padrino for now.
+unless defined?(Padrino)
+  class Widget < ActiveRecord::Base
+    def do_work(*args)
+      Widget.first
+    end
+
+    def do_error(*args)
+      raise "FakeTestError"
+    end
   end
 
-  def do_error(*args)
-    raise "FakeTestError"
-  end
-end
-
-class CreateWidgets < ActiveRecord::Migration
-  def change
-    create_table :widgets do |t|
-      t.string :name
-      t.text :description
-      t.timestamps
+  class CreateWidgets < ActiveRecord::Migration
+    def change
+      create_table :widgets do |t|
+        t.string :name
+        t.text :description
+        t.timestamps
+      end
     end
   end
 end


### PR DESCRIPTION
Our instrumentation breaks under Grape 0.14 which was released last week.

The symptom is that the grape app will return 500s with a stack trace pointing to one of our hook points.

Unformatted backtrace/details:
```
  "ErrorClass"=>"ArgumentError",
  "ErrorMsg"=>"wrong number of arguments (0 for 1)",
  "Backtrace"=>
   "/home/pglombardo/Projects/ruby-traceview/lib/traceview/frameworks/grape.rb:23:in `run_with_traceview'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/endpoint.rb:314:in `block in build_stack'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/middleware/base.rb:25:in `call'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/middleware/base.rb:25:in `call!'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/middleware/base.rb:19:in `call'\r\n/home/pglombardo/Projects/ruby-traceview/lib/traceview/inst/rack.rb:99:in `call'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/middleware/error.rb:27:in `block in call!'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/middleware/error.rb:26:in `catch'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/middleware/error.rb:26:in `call!'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/middleware/base.rb:19:in `call'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rack-1.5.5/lib/rack/head.rb:11:in `call'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/endpoint.rb:215:in `call!'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/endpoint.rb:209:in `call'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rack-mount-0.8.3/lib/rack/mount/route_set.rb:152:in `block in call'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rack-mount-0.8.3/lib/rack/mount/code_generation.rb:96:in `block in recognize'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rack-mount-0.8.3/lib/rack/mount/code_generation.rb:68:in `optimized_each'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rack-mount-0.8.3/lib/rack/mount/code_generation.rb:95:in `recognize'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rack-mount-0.8.3/lib/rack/mount/route_set.rb:141:in `call'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/api.rb:114:in `call'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/api.rb:44:in `call!'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/grape-0.14.0/lib/grape/api.rb:39:in `call'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rack-1.5.5/lib/rack/lint.rb:49:in `_call'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rack-1.5.5/lib/rack/lint.rb:37:in `call'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rack-test-0.6.3/lib/rack/mock_session.rb:30:in `request'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rack-test-0.6.3/lib/rack/test.rb:244:in `process_request'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rack-test-0.6.3/lib/rack/test.rb:58:in `get'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/2.2.0/forwardable.rb:183:in `get'\r\n/home/pglombardo/Projects/ruby-traceview/test/frameworks/grape_test.rb:99:in `block (2 levels) in <top (required)>'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/minitest-5.8.3/lib/minitest/test.rb:108:in `block (3 levels) in run'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/minitest-5.8.3/lib/minitest/test.rb:205:in `capture_exceptions'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/minitest-5.8.3/lib/minitest/test.rb:105:in `block (2 levels) in run'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/minitest-5.8.3/lib/minitest/test.rb:256:in `time_it'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/minitest-5.8.3/lib/minitest/test.rb:104:in `block in run'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/minitest-5.8.3/lib/minitest.rb:334:in `on_signal'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/minitest-5.8.3/lib/minitest/test.rb:276:in `with_info_handler'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/minitest-5.8.3/lib/minitest/test.rb:103:in `run'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/minitest-reporters-1.0.17/lib/minitest/reporters.rb:43:in `run_with_hooks'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/minitest-5.8.3/lib/minitest.rb:781:in `run_one_method'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/minitest-5.8.3/lib/minitest.rb:308:in `run_one_method'\r\n/home/pglombardo/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/minitest-5.8.3/lib/minitest.rb:296:in `block (2 levels) in run'\r\n/home/pglombardo/.rbenv/versions/2.
```