### PR TITLE
ActiveRecord reporting invalid SQL Flavor

### DIFF
--- a/gemfiles/delayed_job.gemfile
+++ b/gemfiles/delayed_job.gemfile
@@ -10,18 +10,6 @@ group :development, :test do
   gem 'bson'
 end
 
-group :development do
-  gem 'ruby-debug',   :platforms => [ :mri_18, :jruby ]
-  gem 'debugger',     :platform  =>   :mri_19
-  gem 'byebug',       :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  if RUBY_VERSION > '1.8.7'
-    gem 'pry'
-    gem 'pry-byebug', :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  else
-    gem 'pry', '0.9.12.4'
-  end
-end
-
 if defined?(JRUBY_VERSION)
   gem 'sinatra', :require => false
   gem 'activerecord-jdbc-adapter'

--- a/gemfiles/frameworks.gemfile
+++ b/gemfiles/frameworks.gemfile
@@ -14,18 +14,6 @@ group :development, :test do
   end
 end
 
-group :development do
-  gem 'ruby-debug',   :platforms => [ :mri_18, :jruby ]
-  gem 'debugger',     :platform  =>   :mri_19
-  gem 'byebug',       :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  if RUBY_VERSION > '1.8.7'
-    gem 'pry'
-    gem 'pry-byebug', :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  else
-    gem 'pry', '0.9.12.4'
-  end
-end
-
 if defined?(JRUBY_VERSION)
   gem 'sinatra', :require => false
 else

--- a/gemfiles/libraries.gemfile
+++ b/gemfiles/libraries.gemfile
@@ -24,18 +24,6 @@ group :development, :test do
   end
 end
 
-group :development do
-  gem 'ruby-debug',   :platforms => [ :mri_18, :jruby ]
-  gem 'debugger',     :platform  =>   :mri_19
-  gem 'byebug',       :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  if RUBY_VERSION > '1.8.7'
-    gem 'pry'
-    gem 'pry-byebug', :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  else
-    gem 'pry', '0.9.12.4'
-  end
-end
-
 if defined?(JRUBY_VERSION)
   gem 'sinatra', :require => false
 else

--- a/gemfiles/rails23.gemfile
+++ b/gemfiles/rails23.gemfile
@@ -27,18 +27,6 @@ group :development, :test do
   end
 end
 
-group :development do
-  gem 'ruby-debug',   :platforms => [ :mri_18, :jruby ]
-  gem 'debugger',     :platform  =>   :mri_19
-  gem 'byebug',       :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  if RUBY_VERSION > '1.8.7'
-    gem 'pry'
-    gem 'pry-byebug', :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  else
-    gem 'pry', '0.9.12.4'
-  end
-end
-
 if defined?(JRUBY_VERSION)
   gem 'sinatra', :require => false
 else

--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -27,18 +27,6 @@ group :development, :test do
   end
 end
 
-group :development do
-  gem 'ruby-debug',   :platforms => [ :mri_18, :jruby ]
-  gem 'debugger',     :platform  =>   :mri_19
-  gem 'byebug',       :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  if RUBY_VERSION > '1.8.7'
-    gem 'pry'
-    gem 'pry-byebug', :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  else
-    gem 'pry', '0.9.12.4'
-  end
-end
-
 if defined?(JRUBY_VERSION)
   gem 'sinatra', :require => false
   gem 'activerecord-jdbc-adapter'

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -27,18 +27,6 @@ group :development, :test do
   end
 end
 
-group :development do
-  gem 'ruby-debug',   :platforms => [ :mri_18, :jruby ]
-  gem 'debugger',     :platform  =>   :mri_19
-  gem 'byebug',       :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  if RUBY_VERSION > '1.8.7'
-    gem 'pry'
-    gem 'pry-byebug', :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  else
-    gem 'pry', '0.9.12.4'
-  end
-end
-
 if defined?(JRUBY_VERSION)
   gem 'sinatra', :require => false
   gem 'activerecord-jdbc-adapter'

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -27,18 +27,6 @@ group :development, :test do
   end
 end
 
-group :development do
-  gem 'ruby-debug',   :platforms => [ :mri_18, :jruby ]
-  gem 'debugger',     :platform  =>   :mri_19
-  gem 'byebug',       :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  if RUBY_VERSION > '1.8.7'
-    gem 'pry'
-    gem 'pry-byebug', :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  else
-    gem 'pry', '0.9.12.4'
-  end
-end
-
 if defined?(JRUBY_VERSION)
   gem 'sinatra', :require => false
   gem 'activerecord-jdbc-adapter'

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -10,18 +10,6 @@ group :development, :test do
   gem 'bson'
 end
 
-group :development do
-  gem 'ruby-debug',   :platforms => [ :mri_18, :jruby ]
-  gem 'debugger',     :platform  =>   :mri_19
-  gem 'byebug',       :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  if RUBY_VERSION > '1.8.7'
-    gem 'pry'
-    gem 'pry-byebug', :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  else
-    gem 'pry', '0.9.12.4'
-  end
-end
-
 if defined?(JRUBY_VERSION)
   gem 'sinatra', :require => false
   gem 'activerecord-jdbc-adapter'

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -10,18 +10,6 @@ group :development, :test do
   gem 'bson'
 end
 
-group :development do
-  gem 'ruby-debug',   :platforms => [ :mri_18, :jruby ]
-  gem 'debugger',     :platform  =>   :mri_19
-  gem 'byebug',       :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  if RUBY_VERSION > '1.8.7'
-    gem 'pry'
-    gem 'pry-byebug', :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  else
-    gem 'pry', '0.9.12.4'
-  end
-end
-
 if defined?(JRUBY_VERSION)
   gem 'sinatra', :require => false
   gem 'activerecord-jdbc-adapter'

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -10,18 +10,6 @@ group :development, :test do
   gem 'bson'
 end
 
-group :development do
-  gem 'ruby-debug',   :platforms => [ :mri_18, :jruby ]
-  gem 'debugger',     :platform  =>   :mri_19
-  gem 'byebug',       :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  if RUBY_VERSION > '1.8.7'
-    gem 'pry'
-    gem 'pry-byebug', :platforms => [ :mri_20, :mri_21, :mri_22 ]
-  else
-    gem 'pry', '0.9.12.4'
-  end
-end
-
 if defined?(JRUBY_VERSION)
   gem 'sinatra', :require => false
   gem 'activerecord-jdbc-adapter'

--- a/test/frameworks/rails3x_test.rb
+++ b/test/frameworks/rails3x_test.rb
@@ -99,6 +99,9 @@ if defined?(::Rails)
     end
 
     it "should trace rails db calls" do
+      # Skip for JRuby since the java instrumentation
+      # handles DB instrumentation for JRuby
+      skip if defined?(JRUBY_VERSION)
 
       uri = URI.parse('http://127.0.0.1:8140/hello/db')
       r = Net::HTTP.get_response(uri)
@@ -106,12 +109,7 @@ if defined?(::Rails)
       traces = get_all_traces
 
       traces.count.must_equal 12
-      unless defined?(JRUBY_VERSION)
-        # We don't test this under JRuby because the Java instrumentation
-        # for the DB drivers doesn't use our test reporter hence we won't
-        # see all trace events. :-(  To be improved.
-        valid_edges?(traces).must_equal true
-      end
+      valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rack')
 
       traces[4]['Layer'].must_equal "activerecord"

--- a/test/frameworks/rails3x_test.rb
+++ b/test/frameworks/rails3x_test.rb
@@ -5,7 +5,7 @@ require "minitest_helper"
 
 if defined?(::Rails)
 
-  describe "Rails" do
+  describe "Rails3x" do
     before do
       clear_all_traces
     end
@@ -96,6 +96,48 @@ if defined?(::Rails)
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
       r.header['X-Trace'].must_equal traces[4]['X-Trace']
+    end
+
+    it "should trace rails db calls" do
+
+      uri = URI.parse('http://127.0.0.1:8140/hello/db')
+      r = Net::HTTP.get_response(uri)
+
+      traces = get_all_traces
+
+      traces.count.must_equal 12
+      unless defined?(JRUBY_VERSION)
+        # We don't test this under JRuby because the Java instrumentation
+        # for the DB drivers doesn't use our test reporter hence we won't
+        # see all trace events. :-(  To be improved.
+        valid_edges?(traces).must_equal true
+      end
+      validate_outer_layers(traces, 'rack')
+
+      traces[4]['Layer'].must_equal "activerecord"
+      traces[4]['Label'].must_equal "entry"
+      traces[4]['Flavor'].must_equal "postgresql"
+      traces[4]['Query'].must_equal "SELECT \"widgets\".* FROM \"widgets\" "
+      traces[4]['Name'].must_equal "Widget Load"
+      traces[4].key?('Backtrace').must_equal true
+
+      traces[5]['Layer'].must_equal "activerecord"
+      traces[5]['Label'].must_equal "exit"
+
+      traces[6]['Layer'].must_equal "activerecord"
+      traces[6]['Label'].must_equal "entry"
+      traces[6]['Flavor'].must_equal "postgresql"
+      traces[6]['Query'].must_equal "INSERT INTO \"widgets\" (\"created_at\", \"description\", \"name\", \"updated_at\") VALUES ($1, $2, $3, $4) RETURNING \"id\""
+      traces[6]['Name'].must_equal "SQL"
+      traces[6].key?('Backtrace').must_equal true
+      traces[6].key?('QueryArgs').must_equal true
+
+      traces[7]['Layer'].must_equal "activerecord"
+      traces[7]['Label'].must_equal "exit"
+
+      # Validate the existence of the response header
+      r.header.key?('X-Trace').must_equal true
+      r.header['X-Trace'].must_equal traces[11]['X-Trace']
     end
   end
 end

--- a/test/frameworks/rails4x_test.rb
+++ b/test/frameworks/rails4x_test.rb
@@ -5,7 +5,7 @@ require "minitest_helper"
 
 if defined?(::Rails)
 
-  describe "Rails" do
+  describe "Rails4x" do
     before do
       clear_all_traces
     end
@@ -53,6 +53,48 @@ if defined?(::Rails)
       # Validate the existence of the response header
       r.header.key?('X-Trace').must_equal true
       r.header['X-Trace'].must_equal traces[6]['X-Trace']
+    end
+
+    it "should trace rails db calls" do
+
+      uri = URI.parse('http://127.0.0.1:8140/hello/db')
+      r = Net::HTTP.get_response(uri)
+
+      traces = get_all_traces
+
+      traces.count.must_equal 11
+      unless defined?(JRUBY_VERSION)
+        # We don't test this under JRuby because the Java instrumentation
+        # for the DB drivers doesn't use our test reporter hence we won't
+        # see all trace events. :-(  To be improved.
+        valid_edges?(traces).must_equal true
+      end
+      validate_outer_layers(traces, 'rack')
+
+      traces[3]['Layer'].must_equal "activerecord"
+      traces[3]['Label'].must_equal "entry"
+      traces[3]['Flavor'].must_equal "postgresql"
+      traces[3]['Query'].must_equal "SELECT  \"widgets\".* FROM \"widgets\"  ORDER BY \"widgets\".\"id\" ASC LIMIT 1"
+      traces[3]['Name'].must_equal "Widget Load"
+      traces[3].key?('Backtrace').must_equal true
+
+      traces[4]['Layer'].must_equal "activerecord"
+      traces[4]['Label'].must_equal "exit"
+
+      traces[5]['Layer'].must_equal "activerecord"
+      traces[5]['Label'].must_equal "entry"
+      traces[5]['Flavor'].must_equal "postgresql"
+      traces[5]['Query'].must_equal "INSERT INTO \"widgets\" (\"name\", \"description\", \"created_at\", \"updated_at\") VALUES ($1, $2, $3, $4) RETURNING \"id\""
+      traces[5]['Name'].must_equal "SQL"
+      traces[5].key?('Backtrace').must_equal true
+      traces[5].key?('QueryArgs').must_equal true
+
+      traces[6]['Layer'].must_equal "activerecord"
+      traces[6]['Label'].must_equal "exit"
+
+      # Validate the existence of the response header
+      r.header.key?('X-Trace').must_equal true
+      r.header['X-Trace'].must_equal traces[10]['X-Trace']
     end
 
     it "should trace a request to a rails metal stack" do

--- a/test/frameworks/rails4x_test.rb
+++ b/test/frameworks/rails4x_test.rb
@@ -56,6 +56,9 @@ if defined?(::Rails)
     end
 
     it "should trace rails db calls" do
+      # Skip for JRuby since the java instrumentation
+      # handles DB instrumentation for JRuby
+      skip if defined?(JRUBY_VERSION)
 
       uri = URI.parse('http://127.0.0.1:8140/hello/db')
       r = Net::HTTP.get_response(uri)
@@ -63,12 +66,7 @@ if defined?(::Rails)
       traces = get_all_traces
 
       traces.count.must_equal 11
-      unless defined?(JRUBY_VERSION)
-        # We don't test this under JRuby because the Java instrumentation
-        # for the DB drivers doesn't use our test reporter hence we won't
-        # see all trace events. :-(  To be improved.
-        valid_edges?(traces).must_equal true
-      end
+      valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rack')
 
       traces[3]['Layer'].must_equal "activerecord"

--- a/test/servers/rails3x_8140.rb
+++ b/test/servers/rails3x_8140.rb
@@ -39,6 +39,7 @@ class Rails32MetalStack < Rails::Application
   routes.append do
     get "/hello/world" => "hello#world"
     get "/hello/metal" => "ferro#world"
+    get "/hello/db"    => "hello#db"
   end
 
   # Enable cache classes. Production style.
@@ -71,6 +72,13 @@ end
 class HelloController < ActionController::Base
   def world
     render :text => "Hello world!"
+  end
+
+  def db
+    Widget.all.first
+    w = Widget.new(:name => 'blah', :description => 'This is an amazing widget.')
+    w.save
+    render :text => "Hello database!"
   end
 end
 

--- a/test/servers/rails4x_8140.rb
+++ b/test/servers/rails4x_8140.rb
@@ -40,6 +40,7 @@ class Rails40MetalStack < Rails::Application
   routes.append do
     get "/hello/world" => "hello#world"
     get "/hello/metal" => "ferro#world"
+    get "/hello/db"    => "hello#db"
   end
 
   # Enable cache classes. Production style.
@@ -72,6 +73,13 @@ end
 class HelloController < ActionController::Base
   def world
     render :text => "Hello world!"
+  end
+
+  def db
+    Widget.all.first
+    w = Widget.new(:name => 'blah', :description => 'This is an amazing widget.')
+    w.save
+    render :text => "Hello database!"
   end
 end
 

--- a/traceview.gemspec
+++ b/traceview.gemspec
@@ -23,7 +23,22 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('json', '>= 0')
   s.add_runtime_dependency('bson', '< 4.0')
-  s.add_development_dependency('rake', '>= 0')
+
+  # Development dependencies used in gem development & testing
+  s.add_development_dependency('rake', '>= 0.9.0')
+
+  case RUBY_VERSION
+  when /^1\.8/
+    s.add_development_dependency('ruby-debug', '>= 0.10.1')
+    s.add_development_dependency('pry', '>= 0.9.12.4')
+  when /^1\.9/
+    s.add_development_dependency('debugger', '>= 1.6.7')
+    s.add_development_dependency('pry', '>= 0.10.0')
+  when /^2\./
+    s.add_development_dependency('byebug', '>= 8.0.0')
+    s.add_development_dependency('pry', '>= 0.10.0')
+    s.add_development_dependency('pry-byebug', '>= 3.0.0')
+  end
 
   s.required_ruby_version = '>= 1.8.6'
 end


### PR DESCRIPTION
For the mysql2 adapter, we're incorrectly reporting 'mysql2' for the adapter flavor.  We should just report mysql.

- [x] Fix `Flavor` reporting
- [x] Add tests to validate