### PR TITLE
Gem dependency breaks Ruby 1.8.7 install

### DIFF
--- a/gemfiles/delayed_job.gemfile
+++ b/gemfiles/delayed_job.gemfile
@@ -7,7 +7,7 @@ group :development, :test do
   gem 'minitest-debugger', :require => false
   gem 'rack-test'
   gem 'puma'
-  gem 'bson'
+  gem 'bson', '< 4.0'
 end
 
 if defined?(JRUBY_VERSION)

--- a/gemfiles/frameworks.gemfile
+++ b/gemfiles/frameworks.gemfile
@@ -10,7 +10,7 @@ group :development, :test do
   if RUBY_VERSION < '1.9.3'
     gem 'bson', '<= 1.12.3'
   else
-    gem 'bson'
+    gem 'bson', '< 4.0'
   end
 end
 

--- a/gemfiles/libraries.gemfile
+++ b/gemfiles/libraries.gemfile
@@ -20,7 +20,7 @@ group :development, :test do
   if RUBY_VERSION < '1.9.3'
     gem 'bson', '<= 1.12.3'
   else
-    gem 'bson'
+    gem 'bson', '< 4.0'
   end
 end
 

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -23,7 +23,7 @@ group :development, :test do
   if RUBY_VERSION < '1.9.3'
     gem 'bson', '<= 1.12.3'
   else
-    gem 'bson'
+    gem 'bson', '< 4.0'
   end
 end
 

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -7,7 +7,7 @@ group :development, :test do
   gem 'minitest-debugger', :require => false
   gem 'rack-test'
   gem 'puma'
-  gem 'bson'
+  gem 'bson', '< 4.0'
 end
 
 if defined?(JRUBY_VERSION)

--- a/traceview.gemspec
+++ b/traceview.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.extensions = ['ext/oboe_metal/extconf.rb'] unless defined?(JRUBY_VERSION)
 
   s.add_runtime_dependency('json', '>= 0')
-  s.add_runtime_dependency('bson', '< 4.0')
 
   # Development dependencies used in gem development & testing
   s.add_development_dependency('rake', '>= 0.9.0')


### PR DESCRIPTION
We depend on the bson gem but recent versions don't support Ruby 1.8 and even Ruby 1.9.  So declaring it as a dependency gives us inconsistent results across ruby versions.