### PR TITLE
Collect methods should ensure a hash return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ https://github.com/appneta/oboe-ruby/releases
 
 Dates in this file are in the format MM/DD/YYYY.
 
+# traceview 3.5.0
+
+This minor release includes the following new feature:
+
+* New [bunny](https://github.com/ruby-amqp/bunny) (Rabbitmq) client instrumentation: #129
+
+Pushed to Rubygems:
+
+https://rubygems.org/gems/traceview/versions/3.5.0
+https://rubygems.org/gems/traceview/versions/3.5.0-java
+
 # traceview 3.4.2
 
 This patch release includes the following fixes:

--- a/lib/traceview/inst/bunny.rb
+++ b/lib/traceview/inst/bunny.rb
@@ -58,6 +58,8 @@ module TraceView
           kvs
         rescue => e
           TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
+        ensure
+          return kvs
         end
       end
 

--- a/lib/traceview/inst/curb.rb
+++ b/lib/traceview/inst/curb.rb
@@ -39,6 +39,8 @@ module TraceView
       rescue => e
         TraceView.logger.debug "[traceview/debug] Error capturing curb KVs: #{e.message}"
         TraceView.logger.debug e.backtrace.join('\n') if ::TraceView::Config[:verbose]
+      ensure
+        return kvs
       end
 
       ##

--- a/lib/traceview/inst/httpclient.rb
+++ b/lib/traceview/inst/httpclient.rb
@@ -33,6 +33,8 @@ module TraceView
       rescue => e
         TraceView.logger.debug "[traceview/debug] Error capturing httpclient KVs: #{e.message}"
         TraceView.logger.debug e.backtrace.join('\n') if ::TraceView::Config[:verbose]
+      ensure
+        return kvs
       end
 
       def do_request_with_traceview(method, uri, query, body, header, &block)

--- a/lib/traceview/inst/mongo.rb
+++ b/lib/traceview/inst/mongo.rb
@@ -120,23 +120,22 @@ if defined?(::Mongo) && TraceView::Config[:mongo][:enabled]
         include TraceView::Inst::Mongo
 
         def traceview_collect(m, args)
-          begin
-            report_kvs = {}
-            report_kvs[:Flavor] = TraceView::Inst::Mongo::FLAVOR
+          kvs = {}
+          kvs[:Flavor] = TraceView::Inst::Mongo::FLAVOR
 
-            report_kvs[:Database] = @db.name
-            report_kvs[:RemoteHost] = @db.connection.host
-            report_kvs[:RemotePort] = @db.connection.port
-            report_kvs[:Collection] = @name
+          kvs[:Database] = @db.name
+          kvs[:RemoteHost] = @db.connection.host
+          kvs[:RemotePort] = @db.connection.port
+          kvs[:Collection] = @name
 
-            report_kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:mongo][:collect_backtraces]
+          kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:mongo][:collect_backtraces]
 
-            report_kvs[:QueryOp] = m
-            report_kvs[:Query] = args[0].to_json if args && !args.empty? && args[0].class == Hash
-          rescue StandardError => e
-            TraceView.logger.debug "[traceview/debug] Exception in traceview_collect KV collection: #{e.inspect}"
-          end
-          report_kvs
+          kvs[:QueryOp] = m
+          kvs[:Query] = args[0].to_json if args && !args.empty? && args[0].class == Hash
+        rescue StandardError => e
+          TraceView.logger.debug "[traceview/debug] Exception in traceview_collect KV collection: #{e.inspect}"
+        ensure
+          return kvs
         end
 
         # Instrument Collection write operations

--- a/lib/traceview/version.rb
+++ b/lib/traceview/version.rb
@@ -7,8 +7,8 @@ module TraceView
   # traceview.gemspec during gem build process
   module Version
     MAJOR = 3
-    MINOR = 4
-    PATCH = 2
+    MINOR = 5
+    PATCH = 0
     BUILD = nil
 
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')


### PR DESCRIPTION
We use `collect` methods to collect up values for reporting.  In error conditions, it's possible that those methods won't return the collected KVs (up to the point of an unexpected condition).

These collect methods are "do the best you can and don't break" methodology.  We should assure this by returning the hash of collected values regardless if an error was encountered or not.