### PR TITLE
Add support for new Rails API controller type

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,14 @@ Rake::TestTask.new do |t|
   when /rails/
     # Pre-load rails to get the major version number
     require 'rails'
-    t.test_files = FileList["test/frameworks/rails#{Rails::VERSION::MAJOR}x_test.rb"]
+
+    if Rails::VERSION::MAJOR == 5
+      t.test_files = FileList["test/frameworks/rails#{Rails::VERSION::MAJOR}x_test.rb"] +
+                     FileList["test/frameworks/rails#{Rails::VERSION::MAJOR}x_api_test.rb"]
+    else
+      t.test_files = FileList["test/frameworks/rails#{Rails::VERSION::MAJOR}x_test.rb"]
+    end
+
   when /frameworks/
     t.test_files = FileList['test/frameworks/sinatra*_test.rb'] +
                    FileList['test/frameworks/padrino*_test.rb'] +

--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -11,8 +11,8 @@ module TraceView
   module Config
     @@config = {}
 
-    @@instrumentation = [:action_controller, :action_view, :active_record,
-                         :bunnyclient, :bunnyconsumer, :cassandra, :curb,
+    @@instrumentation = [:action_controller, :action_controller_api, :action_view,
+                         :active_record, :bunnyclient, :bunnyconsumer, :cassandra, :curb,
                          :dalli, :delayed_jobclient, :delayed_jobworker,
                          :em_http_request, :excon, :faraday, :grape,
                          :httpclient, :nethttp, :memcached,
@@ -44,6 +44,7 @@ module TraceView
 
       # Set collect_backtraces defaults
       TraceView::Config[:action_controller][:collect_backtraces] = true
+      TraceView::Config[:action_controller_api][:collect_backtraces] = true
       TraceView::Config[:active_record][:collect_backtraces] = true
       TraceView::Config[:bunnyclient][:collect_backtraces] = false
       TraceView::Config[:bunnyconsumer][:collect_backtraces] = false

--- a/lib/traceview/frameworks/rails/inst/action_controller.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller.rb
@@ -73,8 +73,15 @@ module TraceView
 end
 
 if defined?(ActionController::Base) && TraceView::Config[:action_controller][:enabled]
-  TraceView.logger.info '[traceview/loading] Instrumenting actioncontroler' if TraceView::Config[:verbose]
+  TraceView.logger.info '[traceview/loading] Instrumenting actioncontroller' if TraceView::Config[:verbose]
   require "traceview/frameworks/rails/inst/action_controller#{Rails::VERSION::MAJOR}"
   ::TraceView::Util.send_include(::ActionController::Base, TraceView::Inst::ActionController)
+
+  # ActionController::API
+  if Rails::VERSION::MAJOR == 5
+    TraceView.logger.info '[traceview/loading] Instrumenting actioncontroller api' if TraceView::Config[:verbose]
+    require "traceview/frameworks/rails/inst/action_controller#{Rails::VERSION::MAJOR}_api"
+    ::TraceView::Util.send_include(::ActionController::API, TraceView::Inst::ActionControllerAPI)
+  end
 end
 # vim:set expandtab:tabstop=2

--- a/lib/traceview/frameworks/rails/inst/action_controller.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller.rb
@@ -72,16 +72,18 @@ module TraceView
   end
 end
 
+# ActionController::Base
 if defined?(ActionController::Base) && TraceView::Config[:action_controller][:enabled]
   TraceView.logger.info '[traceview/loading] Instrumenting actioncontroller' if TraceView::Config[:verbose]
   require "traceview/frameworks/rails/inst/action_controller#{Rails::VERSION::MAJOR}"
   ::TraceView::Util.send_include(::ActionController::Base, TraceView::Inst::ActionController)
-
-  # ActionController::API
-  if Rails::VERSION::MAJOR == 5
-    TraceView.logger.info '[traceview/loading] Instrumenting actioncontroller api' if TraceView::Config[:verbose]
-    require "traceview/frameworks/rails/inst/action_controller#{Rails::VERSION::MAJOR}_api"
-    ::TraceView::Util.send_include(::ActionController::API, TraceView::Inst::ActionControllerAPI)
-  end
 end
+
+# ActionController::API (Rails 5+)
+if defined?(ActionController::API) && TraceView::Config[:action_controller_api][:enabled]
+  TraceView.logger.info '[traceview/loading] Instrumenting actioncontroller api' if TraceView::Config[:verbose]
+  require "traceview/frameworks/rails/inst/action_controller#{Rails::VERSION::MAJOR}_api"
+  ::TraceView::Util.send_include(::ActionController::API, TraceView::Inst::ActionControllerAPI)
+end
+
 # vim:set expandtab:tabstop=2

--- a/lib/traceview/frameworks/rails/inst/action_controller5_api.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller5_api.rb
@@ -1,0 +1,39 @@
+# Copyright (c) 2016 AppNeta, Inc.
+# All rights reserved.
+
+module TraceView
+  module Inst
+    #
+    # ActionController
+    #
+    # This modules contains the instrumentation code specific
+    # to Rails v5
+    #
+    module ActionControllerAPI
+      include ::TraceView::Inst::RailsBase
+
+      def self.included(base)
+        base.class_eval do
+          alias_method_chain :process_action, :traceview
+          alias_method_chain :render, :traceview
+        end
+      end
+
+      def process_action_with_traceview(method_name, *args)
+        report_kvs = {
+          :Controller   => self.class.name,
+          :Action       => self.action_name,
+        }
+
+        TraceView::API.log_entry('rails-api', report_kvs)
+        process_action_without_traceview(method_name, *args)
+
+      rescue Exception => e
+        TraceView::API.log_exception(nil, e) if log_rails_error?(e)
+        raise
+      ensure
+        TraceView::API.log_exit('rails-api')
+      end
+    end
+  end
+end

--- a/test/frameworks/rails5x_api_test.rb
+++ b/test/frameworks/rails5x_api_test.rb
@@ -1,0 +1,103 @@
+# Copyright (c) 2015 AppNeta, Inc.
+# All rights reserved.
+
+require "minitest_helper"
+
+if defined?(::Rails)
+
+  describe "Rails5xAPI" do
+    before do
+      clear_all_traces
+      ENV['DBTYPE'] = "postgresql" unless ENV['DBTYPE']
+    end
+
+    it "should trace a request to a rails api stack" do
+
+      uri = URI.parse('http://127.0.0.1:8150/monkey/hello')
+      r = Net::HTTP.get_response(uri)
+
+      traces = get_all_traces
+
+      traces.count.must_equal 7
+      unless defined?(JRUBY_VERSION)
+        # We don't test this under JRuby because the Java instrumentation
+        # for the DB drivers doesn't use our test reporter hence we won't
+        # see all trace events. :-(  To be improved.
+        valid_edges?(traces).must_equal true
+      end
+      validate_outer_layers(traces, 'rack')
+
+      traces[0]['Layer'].must_equal "rack"
+      traces[0]['Label'].must_equal "entry"
+      traces[0]['URL'].must_equal "/monkey/hello"
+
+      traces[1]['Layer'].must_equal "rack"
+      traces[1]['Label'].must_equal "info"
+
+      traces[2]['Layer'].must_equal "rails-api"
+      traces[2]['Label'].must_equal "entry"
+      traces[2]['Controller'].must_equal "MonkeyController"
+      traces[2]['Action'].must_equal "hello"
+
+      traces[3]['Layer'].must_equal "actionview"
+      traces[3]['Label'].must_equal "entry"
+
+      traces[4]['Layer'].must_equal "actionview"
+      traces[4]['Label'].must_equal "exit"
+
+      traces[5]['Layer'].must_equal "rails-api"
+      traces[5]['Label'].must_equal "exit"
+
+      traces[6]['Layer'].must_equal "rack"
+      traces[6]['Label'].must_equal "exit"
+
+      # Validate the existence of the response header
+      r.header.key?('X-Trace').must_equal true
+      r.header['X-Trace'].must_equal traces[6]['X-Trace']
+    end
+
+    it "should capture errors" do
+      uri = URI.parse('http://127.0.0.1:8150/monkey/error')
+      r = Net::HTTP.get_response(uri)
+
+      traces = get_all_traces
+
+      traces.count.must_equal 6
+      unless defined?(JRUBY_VERSION)
+        # We don't test this under JRuby because the Java instrumentation
+        # for the DB drivers doesn't use our test reporter hence we won't
+        # see all trace events. :-(  To be improved.
+        valid_edges?(traces).must_equal true
+      end
+      validate_outer_layers(traces, 'rack')
+
+      traces[0]['Layer'].must_equal "rack"
+      traces[0]['Label'].must_equal "entry"
+      traces[0]['URL'].must_equal "/monkey/error"
+
+      traces[1]['Layer'].must_equal "rack"
+      traces[1]['Label'].must_equal "info"
+
+      traces[2]['Layer'].must_equal "rails-api"
+      traces[2]['Label'].must_equal "entry"
+      traces[2]['Controller'].must_equal "MonkeyController"
+      traces[2]['Action'].must_equal "error"
+
+      traces[3]['Label'].must_equal "error"
+      traces[3]['ErrorClass'].must_equal "RuntimeError"
+      traces[3]['ErrorMsg'].must_equal "Rails API fake error from controller"
+      traces[3].key?('Backtrace').must_equal true
+
+      traces[4]['Layer'].must_equal "rails-api"
+      traces[4]['Label'].must_equal "exit"
+
+      traces[5]['Layer'].must_equal "rack"
+      traces[5]['Label'].must_equal "exit"
+
+      # Validate the existence of the response header
+      r.header.key?('X-Trace').must_equal true
+      r.header['X-Trace'].must_equal traces[5]['X-Trace']
+    end
+
+  end
+end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -59,6 +59,7 @@ when /delayed_job/
 
 when /rails5/
   require './test/servers/rails5x_8140'
+  require './test/servers/rails5x_api_8150'
 
 when /rails4/
   require './test/servers/rails4x_8140'

--- a/test/servers/rails5x_api_8150.rb
+++ b/test/servers/rails5x_api_8150.rb
@@ -1,0 +1,99 @@
+# Taken from: https://www.amberbit.com/blog/2014/2/14/putting-ruby-on-rails-on-a-diet/
+# Port of https://gist.github.com/josevalim/1942658 to Rails 4
+# Original author: Jose Valim
+# Updated by: Peter Giacomo Lombardo
+#
+# Run this file with:
+#
+#   bundle exec RAILS_ENV=production rackup -p 3000 -s thin
+#
+# And access:
+#
+#   http://localhost:3000/hello/world
+#
+# The following lines should come as no surprise. Except by
+# ActionController::Metal, it follows the same structure of
+# config/application.rb, config/environment.rb and config.ru
+# existing in any Rails 4 app. Here they are simply in one
+# file and without the comments.
+#
+
+# Set the database.  Default is postgresql.
+if ENV['DBTYPE'] == 'mysql2'
+  TraceView::Test.set_mysql2_env
+elsif ENV['DBTYPE'] == 'postgresql'
+  TraceView::Test.set_postgresql_env
+else
+  TV.logger.warn "Unidentified DBTYPE: #{ENV['DBTYPE']}" unless ENV['DBTYPE'] == "postgresql"
+  TV.logger.debug "Defaulting to postgres DB for background Rails server."
+  TraceView::Test.set_postgresql_env
+end
+
+require "rails"
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "active_job/railtie"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_view/railtie"
+require "action_cable/engine"
+# require "sprockets/railtie"
+require "rails/test_unit/railtie"
+
+require 'rack/handler/puma'
+require File.expand_path(File.dirname(__FILE__) + '/../models/widget')
+
+TraceView.logger.info "[traceview/info] Starting background utility rails app on localhost:8140."
+
+ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
+
+unless ActiveRecord::Base.connection.table_exists? 'widgets'
+  ActiveRecord::Migration.run(CreateWidgets)
+end
+
+module Rails50APIStack
+  class Application < Rails::Application
+    config.api_only = true
+
+    # Enable cache classes. Production style.
+    config.cache_classes = true
+    config.eager_load = false
+
+    # uncomment below to display errors
+    # config.consider_all_requests_local = true
+
+    config.active_support.deprecation = :stderr
+
+    # Here you could remove some middlewares, for example
+    # Rack::Lock, ActionDispatch::Flash and  ActionDispatch::BestStandardsSupport below.
+    # The remaining stack is printed on rackup (for fun!).
+    # Rails API has config.middleware.api_only! to get
+    # rid of browser related middleware.
+    config.middleware.delete Rack::Lock
+    config.middleware.delete ActionDispatch::Flash
+
+    # We need a secret token for session, cookies, etc.
+    config.secret_token = "48837489qkuweoiuoqwehisuakshdjksadhaisdy78o34y138974xyqp9rmye8yrpiokeuioqwzyoiuxftoyqiuxrhm3iou1hrzmjk"
+    config.secret_key_base = "2049671-96803948"
+
+  end
+end
+
+#################################################
+#  Controllers
+#################################################
+
+class MonkeyController < ActionController::API
+  def hello
+    render :json => { :Response => "Hello API!"}
+  end
+end
+
+Rails50APIStack::Application.initialize!
+
+Thread.new do
+  Rack::Handler::Puma.run(Rails50APIStack::Application.to_app, {:Host => '127.0.0.1', :Port => 8150})
+end
+
+sleep(2)

--- a/test/servers/rails5x_api_8150.rb
+++ b/test/servers/rails5x_api_8150.rb
@@ -44,7 +44,7 @@ require "rails/test_unit/railtie"
 require 'rack/handler/puma'
 require File.expand_path(File.dirname(__FILE__) + '/../models/widget')
 
-TraceView.logger.info "[traceview/info] Starting background utility rails app on localhost:8140."
+TraceView.logger.info "[traceview/info] Starting background utility rails app on localhost:8150."
 
 ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
 
@@ -55,6 +55,11 @@ end
 module Rails50APIStack
   class Application < Rails::Application
     config.api_only = true
+
+    routes.append do
+      get "/monkey/hello" => "monkey#hello"
+      get "/monkey/error" => "monkey#error"
+    end
 
     # Enable cache classes. Production style.
     config.cache_classes = true
@@ -76,7 +81,6 @@ module Rails50APIStack
     # We need a secret token for session, cookies, etc.
     config.secret_token = "48837489qkuweoiuoqwehisuakshdjksadhaisdy78o34y138974xyqp9rmye8yrpiokeuioqwzyoiuxftoyqiuxrhm3iou1hrzmjk"
     config.secret_key_base = "2049671-96803948"
-
   end
 end
 
@@ -86,7 +90,13 @@ end
 
 class MonkeyController < ActionController::API
   def hello
-    render :json => { :Response => "Hello API!"}
+    #render :json => { :Response => "Hello API!"}.to_json
+    # Work around for Rails beta issue with rendering json
+    render :plain => { :Response => "Hello API!"}.to_json, content_type: 'application/json'
+  end
+
+  def error
+    raise "Rails API fake error from controller"
   end
 end
 

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -30,9 +30,10 @@ describe "TraceView::Config" do
     instrumentation = TraceView::Config.instrumentation
 
     # Verify the number of individual instrumentations
-    instrumentation.count.must_equal 29
+    instrumentation.count.must_equal 30
 
     TraceView::Config[:action_controller][:enabled].must_equal true
+    TraceView::Config[:action_controller_api][:enabled].must_equal true
     TraceView::Config[:action_view][:enabled].must_equal true
     TraceView::Config[:active_record][:enabled].must_equal true
     TraceView::Config[:bunnyclient][:enabled].must_equal true
@@ -63,6 +64,7 @@ describe "TraceView::Config" do
     TraceView::Config[:typhoeus][:enabled].must_equal true
 
     TraceView::Config[:action_controller][:log_args].must_equal true
+    TraceView::Config[:action_controller_api][:log_args].must_equal true
     TraceView::Config[:action_view][:log_args].must_equal true
     TraceView::Config[:active_record][:log_args].must_equal true
     TraceView::Config[:bunnyclient][:log_args].must_equal true


### PR DESCRIPTION
Rails 5 merged in the Rails API project which uses a new ActionController based off of ActionController::API (instead of ActionController::Base).  It's a stripped down controller class geared towards non browser based API clients.

- [x] Create background Rails API server for test suite
- [x] Add `:action_controller_api` to `TraceView::Config`
- [x] Core ActionController::API instrumentation
- [x] Capture rendering
- [x] Capture error handling
- [x] Add tests for all of the above
