### PR TITLE
Prefer symbols over strings

### DIFF
--- a/lib/joboe_metal.rb
+++ b/lib/joboe_metal.rb
@@ -66,11 +66,11 @@ module Oboe_metal
           cfg = LayerUtil.getLocalSampleRate(nil, nil)
 
           if cfg.hasSampleStartFlag
-            TraceView::Config.tracing_mode = 'always'
+            TraceView::Config.tracing_mode = :always
           elsif cfg.hasSampleThroughFlag
-            TraceView::Config.tracing_mode = 'through'
+            TraceView::Config.tracing_mode = :through
           else
-            TraceView::Config.tracing_mode = 'never'
+            TraceView::Config.tracing_mode = :never
           end
 
           TraceView.sample_rate = cfg.getSampleRate
@@ -205,7 +205,7 @@ case Java::ComTracelyticsAgent::Agent.getStatus
     $stderr.puts '=============================================================='
     $stderr.puts 'TraceView Java Agent not initialized properly.'
     $stderr.puts 'Possibly misconfigured?  Going into no-op mode.'
-    $stderr.puts 'See: http://bit.ly/1zwS5xj'
+    $stderr.puts 'https://docs.appneta.com/installing-jruby-instrumentation'
     $stderr.puts '=============================================================='
 
   when Java::ComTracelyticsAgent::Agent::AgentStatus::UNINITIALIZED

--- a/lib/oboe_metal.rb
+++ b/lib/oboe_metal.rb
@@ -118,9 +118,9 @@ module TraceView
         return false if TraceView.never? || (TraceView.through? && !opts.key?('X-TV-Meta'))
 
         # Assure defaults since SWIG enforces Strings
-        layer   = opts[:layer]      ? opts[:layer].to_s.strip      : ''
-        xtrace  = opts[:xtrace]     ? opts[:xtrace].to_s.strip     : ''
-        tv_meta = opts['X-TV-Meta'] ? opts['X-TV-Meta'].to_s.strip : ''
+        layer   = opts[:layer]      ? opts[:layer].to_s.strip.freeze : TV_STR_BLANK
+        xtrace  = opts[:xtrace]     ? opts[:xtrace].to_s.strip       : TV_STR_BLANK
+        tv_meta = opts['X-TV-Meta'] ? opts['X-TV-Meta'].to_s.strip   : TV_STR_BLANK
 
         rv = TraceView::Context.sampleRequest(layer, xtrace, tv_meta)
 

--- a/lib/traceview/api/layerinit.rb
+++ b/lib/traceview/api/layerinit.rb
@@ -10,7 +10,7 @@ module TraceView
       # installed, as well as the version of instrumentation and version of
       # layer.
       #
-      def report_init(layer = 'rack')
+      def report_init(layer = :rack)
         # Don't send __Init in development, test or if the gem
         # isn't fully loaded (e.g. missing c-extension)
         return if %w(development test).include?(ENV['RACK_ENV']) ||
@@ -41,7 +41,7 @@ module TraceView
                          'removed in a subsequent version.'
 
         saved_mode = TraceView::Config[:tracing_mode]
-        TraceView::Config[:tracing_mode] = 'always'
+        TraceView::Config[:tracing_mode] = :always
         yield
       ensure
         TraceView::Config[:tracing_mode] = saved_mode

--- a/lib/traceview/api/logging.rb
+++ b/lib/traceview/api/logging.rb
@@ -247,8 +247,8 @@ module TraceView
       def log_event(layer, label, event, opts = {})
         return unless TraceView.loaded
 
-        event.addInfo(:Layer, layer.to_s) if layer
-        event.addInfo(:Label, label.to_s)
+        event.addInfo('Layer', layer.to_s) if layer
+        event.addInfo('Label', label.to_s)
 
         TraceView.layer = layer if label == :entry
         TraceView.layer = nil   if label == :exit

--- a/lib/traceview/api/logging.rb
+++ b/lib/traceview/api/logging.rb
@@ -68,7 +68,7 @@ module TraceView
                    :Backtrace => exn.backtrace.join("\r\n"))
 
         exn.instance_variable_set(:@oboe_logged, true)
-        log(layer, 'error', kvs)
+        log(layer, :error, kvs)
       end
 
       ##
@@ -118,7 +118,7 @@ module TraceView
         elsif opts.key?('Force')
           # Forced tracing: used by __Init reporting
           opts[:TraceOrigin] = :forced
-          log_event(layer, 'entry', TraceView::Context.startTrace, opts)
+          log_event(layer, :entry, TraceView::Context.startTrace, opts)
 
         elsif TraceView.sample?(opts.merge(:layer => layer, :xtrace => xtrace))
           # Probablistic tracing of a subset of requests based off of
@@ -132,7 +132,7 @@ module TraceView
             opts[:TraceOrigin]       = :always_sampled
           end
 
-          log_event(layer, 'entry', TraceView::Context.startTrace, opts)
+          log_event(layer, :entry, TraceView::Context.startTrace, opts)
         end
       end
 
@@ -152,7 +152,7 @@ module TraceView
       def log_end(layer, opts = {})
         return unless TraceView.loaded
 
-        log_event(layer, 'exit', TraceView::Context.createEvent, opts)
+        log_event(layer, :exit, TraceView::Context.createEvent, opts)
         xtrace = TraceView::Context.toString
         TraceView::Context.clear unless TraceView.has_incoming_context?
         xtrace
@@ -178,7 +178,7 @@ module TraceView
         return unless TraceView.loaded
 
         TraceView.layer_op = op if op
-        log_event(layer, 'entry', TraceView::Context.createEvent, kvs)
+        log_event(layer, :entry, TraceView::Context.createEvent, kvs)
       end
 
       ##
@@ -199,7 +199,7 @@ module TraceView
       def log_info(layer, kvs = {})
         return unless TraceView.loaded
 
-        log_event(layer, 'info', TraceView::Context.createEvent, kvs)
+        log_event(layer, :info, TraceView::Context.createEvent, kvs)
       end
 
       ##
@@ -222,7 +222,7 @@ module TraceView
         return unless TraceView.loaded
 
         TraceView.layer_op = nil if op
-        log_event(layer, 'exit', TraceView::Context.createEvent, kvs)
+        log_event(layer, :exit, TraceView::Context.createEvent, kvs)
       end
 
       ##
@@ -247,11 +247,11 @@ module TraceView
       def log_event(layer, label, event, opts = {})
         return unless TraceView.loaded
 
-        event.addInfo('Layer', layer.to_s) if layer
-        event.addInfo('Label', label.to_s)
+        event.addInfo(:Layer, layer.to_s) if layer
+        event.addInfo(:Label, label.to_s)
 
-        TraceView.layer = layer if label == 'entry'
-        TraceView.layer = nil   if label == 'exit'
+        TraceView.layer = layer if label == :entry
+        TraceView.layer = nil   if label == :exit
 
         opts.each do |k, v|
           value = nil

--- a/lib/traceview/api/logging.rb
+++ b/lib/traceview/api/logging.rb
@@ -177,7 +177,7 @@ module TraceView
       def log_entry(layer, kvs = {}, op = nil)
         return unless TraceView.loaded
 
-        TraceView.layer_op = op if op
+        TraceView.layer_op = op.to_sym if op
         log_event(layer, :entry, TraceView::Context.createEvent, kvs)
       end
 
@@ -250,8 +250,8 @@ module TraceView
         event.addInfo(TV_STR_LAYER, layer.to_s.freeze) if layer
         event.addInfo(TV_STR_LABEL, label.to_s.freeze)
 
-        TraceView.layer = layer if label == :entry
-        TraceView.layer = nil   if label == :exit
+        TraceView.layer = layer.to_sym if label == :entry
+        TraceView.layer = nil          if label == :exit
 
         opts.each do |k, v|
           value = nil

--- a/lib/traceview/api/logging.rb
+++ b/lib/traceview/api/logging.rb
@@ -247,8 +247,8 @@ module TraceView
       def log_event(layer, label, event, opts = {})
         return unless TraceView.loaded
 
-        event.addInfo('Layer', layer.to_s) if layer
-        event.addInfo('Label', label.to_s)
+        event.addInfo(TV_STR_LAYER, layer.to_s.freeze) if layer
+        event.addInfo(TV_STR_LABEL, label.to_s.freeze)
 
         TraceView.layer = layer if label == :entry
         TraceView.layer = nil   if label == :exit

--- a/lib/traceview/api/profiling.rb
+++ b/lib/traceview/api/profiling.rb
@@ -30,7 +30,7 @@ module TraceView
         report_kvs[:ProfileName] ||= profile_name
         report_kvs[:Backtrace] = TraceView::API.backtrace if with_backtrace
 
-        TraceView::API.log(nil, 'profile_entry', report_kvs)
+        TraceView::API.log(nil, :profile_entry, report_kvs)
 
         begin
           yield
@@ -42,7 +42,7 @@ module TraceView
           exit_kvs[:Language] = :ruby
           exit_kvs[:ProfileName] = report_kvs[:ProfileName]
 
-          TraceView::API.log(nil, 'profile_exit', exit_kvs)
+          TraceView::API.log(nil, :profile_exit, exit_kvs)
         end
       end
 

--- a/lib/traceview/api/profiling.rb
+++ b/lib/traceview/api/profiling.rb
@@ -133,8 +133,8 @@ module TraceView
               profile_wrapper(without_traceview, report_kvs, opts, *args, &block)
             end
 
-            alias_method without_traceview, "#{method}"
-            alias_method "#{method}", with_traceview
+            alias_method without_traceview, method.to_s
+            alias_method method.to_s, with_traceview
           end
         elsif class_method
           klass.define_singleton_method(with_traceview) do |*args, &block|
@@ -142,8 +142,8 @@ module TraceView
           end
 
           klass.singleton_class.class_eval do
-            alias_method without_traceview, "#{method}"
-            alias_method "#{method}", with_traceview
+            alias_method without_traceview, method.to_s
+            alias_method method.to_s, with_traceview
           end
         end
         true

--- a/lib/traceview/api/tracing.rb
+++ b/lib/traceview/api/tracing.rb
@@ -126,7 +126,7 @@ module TraceView
           raise
         ensure
           exit_evt.addEdge(TraceView::Context.get)
-          log_event(layer, 'exit', exit_evt)
+          log_event(layer, :exit, exit_evt)
           TraceView::Context.clear
         end
       end

--- a/lib/traceview/api/util.rb
+++ b/lib/traceview/api/util.rb
@@ -17,7 +17,7 @@ module TraceView
       #
       # Return a boolean indicating whether or not key is reserved.
       def valid_key?(key)
-        !%w(Label Layer Edge Timestamp Timestamp_u).include? key.to_s
+        ![:Label, :Layer, :Edge, :Timestamp, :Timestamp_u].include?(key.to_sym)
       end
 
       # Internal: Get the current backtrace.

--- a/lib/traceview/base.rb
+++ b/lib/traceview/base.rb
@@ -115,7 +115,7 @@ module TraceViewBase
   # operation tracing or one instrumented operation calling another.
   #
   def tracing_layer?(layer)
-    TraceView.layer == layer
+    TraceView.layer == layer.to_sym
   end
 
   ##
@@ -125,13 +125,16 @@ module TraceViewBase
   # operation being traced.  This is used in cases of recursive
   # operation tracing or one instrumented operation calling another.
   #
+  # <operation> can be a single symbol or an array of symbols that
+  # will be checked against.
+  #
   # In such cases, we only want to trace the outermost operation.
   #
   def tracing_layer_op?(operation)
     if operation.is_a?(Array)
       return operation.include?(TraceView.layer_op)
     else
-      return TraceView.layer_op == operation
+      return TraceView.layer_op == operation.to_sym
     end
   end
 
@@ -170,7 +173,7 @@ module TraceViewBase
   # False otherwise
   #
   def passthrough?
-    %w(always through).include?(TraceView::Config[:tracing_mode])
+    [:always, :through].include?(TraceView::Config[:tracing_mode])
   end
 
   ##
@@ -244,7 +247,7 @@ module TraceViewBase
   # or not
   #
   def framework?
-    defined?(::Rails) && defined?(::Sinatra) && defined?(::Padrino) && defined?(::Grape)
+    defined?(::Rails) || defined?(::Sinatra) || defined?(::Padrino) || defined?(::Grape)
   end
 
   ##

--- a/lib/traceview/base.rb
+++ b/lib/traceview/base.rb
@@ -22,6 +22,10 @@ SAMPLE_SOURCE_MASK = 0b1111000000000000000000000000
 ZERO_SAMPLE_RATE_MASK   = 0b1111000000000000000000000000
 ZERO_SAMPLE_SOURCE_MASK = 0b0000111111111111111111111111
 
+TV_STR_BLANK = ''.freeze
+TV_STR_LAYER = 'Layer'.freeze
+TV_STR_LABEL = 'Label'.freeze
+
 ##
 # This module is the base module for the various implementations of TraceView reporting.
 # Current variations as of 2014-09-10 are a c-extension, JRuby (using TraceView Java

--- a/lib/traceview/base.rb
+++ b/lib/traceview/base.rb
@@ -150,7 +150,7 @@ module TraceViewBase
   # False otherwise
   #
   def always?
-    TraceView::Config[:tracing_mode].to_s == 'always'
+    TraceView::Config[:tracing_mode].to_sym == :always
   end
 
   ##
@@ -158,7 +158,7 @@ module TraceViewBase
   # False otherwise
   #
   def never?
-    TraceView::Config[:tracing_mode].to_s == 'never'
+    TraceView::Config[:tracing_mode].to_sym == :never
   end
 
   ##
@@ -174,7 +174,7 @@ module TraceViewBase
   # False otherwise
   #
   def through?
-    TraceView::Config[:tracing_mode].to_s == 'through'
+    TraceView::Config[:tracing_mode].to_sym == :through
   end
 
   ##

--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -190,12 +190,12 @@ module TraceView
       # Environment support for OpenShift.
       if ENV.key?('OPENSHIFT_TRACEVIEW_TLYZER_IP')
         # We're running on OpenShift
-        @@config[:tracing_mode] = 'always'
+        @@config[:tracing_mode] = :always
         @@config[:reporter_host] = ENV['OPENSHIFT_TRACEVIEW_TLYZER_IP']
         @@config[:reporter_port] = ENV['OPENSHIFT_TRACEVIEW_TLYZER_PORT']
       else
         # The default configuration
-        @@config[:tracing_mode] = 'through'
+        @@config[:tracing_mode] = :through
         @@config[:reporter_host] = '127.0.0.1'
         @@config[:reporter_port] = '7831'
       end
@@ -265,7 +265,7 @@ module TraceView
 
       # Update liboboe if updating :tracing_mode
       if key == :tracing_mode
-        TraceView.set_tracing_mode(value) if TraceView.loaded
+        TraceView.set_tracing_mode(value.to_sym) if TraceView.loaded
       end
     end
 

--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -266,6 +266,9 @@ module TraceView
       # Update liboboe if updating :tracing_mode
       if key == :tracing_mode
         TraceView.set_tracing_mode(value.to_sym) if TraceView.loaded
+
+        # Make sure that the mode is stored as a symbol
+        @@config[key.to_sym] = value.to_sym
       end
     end
 

--- a/lib/traceview/frameworks/padrino/templates.rb
+++ b/lib/traceview/frameworks/padrino/templates.rb
@@ -19,13 +19,13 @@ module TraceView
             report_kvs[:template] = engine
           end
 
-          if TraceView.tracing_layer_op?('render')
+          if TraceView.tracing_layer_op?(:render)
             # For recursive calls to :render (for sub-partials and layouts),
             # use method profiling.
             begin
               report_kvs[:FunctionName] = :render
               report_kvs[:Class]        = :Rendering
-              report_kvs[:Module]       = 'Padrino'
+              report_kvs[:Module]       = :Padrino
               report_kvs[:File]         = __FILE__
               report_kvs[:LineNumber]   = __LINE__
             rescue StandardError => e
@@ -41,12 +41,12 @@ module TraceView
             # back on exit (a limitation of the TraceView::API.trace
             # block method) This removes the need for an info
             # event to send additonal KVs
-            ::TraceView::API.log_entry('render', {}, 'render')
+            ::TraceView::API.log_entry(:render, {}, :render)
 
             begin
               render_without_traceview(engine, data, options, locals, &block)
             ensure
-              ::TraceView::API.log_exit('render', report_kvs)
+              ::TraceView::API.log_exit(:render, report_kvs)
             end
           end
         else

--- a/lib/traceview/frameworks/rails.rb
+++ b/lib/traceview/frameworks/rails.rb
@@ -43,9 +43,9 @@ module TraceView
       # Force load the TraceView Rails initializer if there is one
       # Prefer traceview.rb but give priority to the legacy tracelytics.rb if it exists
       if ::Rails::VERSION::MAJOR > 2
-        rails_root = "#{::Rails.root}"
+        rails_root = ::Rails.root.to_s
       else
-        rails_root = "#{RAILS_ROOT}"
+        rails_root = RAILS_ROOT.to_s
       end
 
       #

--- a/lib/traceview/frameworks/sinatra/templates.rb
+++ b/lib/traceview/frameworks/sinatra/templates.rb
@@ -15,14 +15,14 @@ module TraceView
           report_kvs[:engine] = engine
           report_kvs[:template] = data
 
-          if TraceView.tracing_layer_op?('render')
+          if TraceView.tracing_layer_op?(:render)
             # For recursive calls to :render (for sub-partials and layouts),
             # use method profiling.
             begin
               name = data
               report_kvs[:FunctionName] = :render
               report_kvs[:Class]        = :Templates
-              report_kvs[:Module]       = 'Sinatra::Templates'
+              report_kvs[:Module]       = :'Sinatra::Templates'
               report_kvs[:File]         = __FILE__
               report_kvs[:LineNumber]   = __LINE__
             rescue StandardError => e
@@ -39,12 +39,12 @@ module TraceView
             # back on exit (a limitation of the TraceView::API.trace
             # block method) This removes the need for an info
             # event to send additonal KVs
-            ::TraceView::API.log_entry('render', {}, 'render')
+            ::TraceView::API.log_entry(:render, {}, :render)
 
             begin
               render_without_traceview(engine, data, options, locals, &block)
             ensure
-              ::TraceView::API.log_exit('render', report_kvs)
+              ::TraceView::API.log_exit(:render, report_kvs)
             end
           end
         else

--- a/lib/traceview/inst/bunny-client.rb
+++ b/lib/traceview/inst/bunny-client.rb
@@ -28,14 +28,14 @@ module TraceView
             kvs[:ExchangeName] = :default
           end
 
-          TraceView::API.log_entry('rabbitmq-client')
+          TraceView::API.log_entry(:'rabbitmq-client')
 
           delete_without_traceview(opts)
         rescue => e
           TraceView::API.log_exception(nil, e)
           raise e
         ensure
-          TraceView::API.log_exit('rabbitmq-client', kvs)
+          TraceView::API.log_exit(:'rabbitmq-client', kvs)
         end
       end
     end
@@ -83,7 +83,7 @@ module TraceView
           kvs[:RoutingKey]  = routing_key if routing_key
           kvs[:Op]          = :publish
 
-          TraceView::API.log_entry('rabbitmq-client')
+          TraceView::API.log_entry(:'rabbitmq-client')
 
           # Pass the tracing context as a header
           opts[:headers] ||= {}
@@ -94,7 +94,7 @@ module TraceView
           TraceView::API.log_exception(nil, e)
           raise e
         ensure
-          TraceView::API.log_exit('rabbitmq-client', kvs)
+          TraceView::API.log_exit(:'rabbitmq-client', kvs)
         end
       end
 
@@ -106,7 +106,7 @@ module TraceView
           kvs = collect_channel_kvs
           kvs[:Op] = :queue
 
-          TraceView::API.log_entry('rabbitmq-client')
+          TraceView::API.log_entry(:'rabbitmq-client')
 
           result = queue_without_traceview(name, opts)
           kvs[:Queue] = result.name
@@ -115,7 +115,7 @@ module TraceView
           TraceView::API.log_exception(nil, e)
           raise e
         ensure
-          TraceView::API.log_exit('rabbitmq-client', kvs)
+          TraceView::API.log_exit(:'rabbitmq-client', kvs)
         end
       end
 
@@ -127,14 +127,14 @@ module TraceView
           kvs = collect_channel_kvs
           kvs[:Op] = :wait_for_confirms
 
-          TraceView::API.log_entry('rabbitmq-client')
+          TraceView::API.log_entry(:'rabbitmq-client')
 
           wait_for_confirms_without_traceview
         rescue => e
           TraceView::API.log_exception(nil, e)
           raise e
         ensure
-          TraceView::API.log_exit('rabbitmq-client', kvs)
+          TraceView::API.log_exit(:'rabbitmq-client', kvs)
         end
       end
     end

--- a/lib/traceview/inst/bunny-consumer.rb
+++ b/lib/traceview/inst/bunny-consumer.rb
@@ -77,7 +77,7 @@ module TraceView
           headers.delete('SourceTrace')
         end
 
-        result = TraceView::API.start_trace('rabbitmq-consumer', nil, report_kvs) do
+        result = TraceView::API.start_trace(:'rabbitmq-consumer', nil, report_kvs) do
           call_without_traceview(*args)
         end
         result[0]

--- a/lib/traceview/inst/curb.rb
+++ b/lib/traceview/inst/curb.rb
@@ -19,7 +19,7 @@ module TraceView
         kvs = {}
 
         if TraceView::Config[:curb][:cross_host]
-          kvs['IsService'] = 1
+          kvs[:IsService] = 1
 
           # Conditionally log query args
           if TraceView::Config[:curb][:log_args]
@@ -33,7 +33,7 @@ module TraceView
 
         # Avoid cross host tracing for blacklisted domains
         kvs[:blacklisted] = TraceView::API.blacklisted?(URI(url).hostname)
-        kvs['Backtrace'] = TraceView::API.backtrace if TraceView::Config[:curb][:collect_backtraces]
+        kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:curb][:collect_backtraces]
 
         kvs
       rescue => e
@@ -59,7 +59,7 @@ module TraceView
           handle_cross_host = TraceView::Config[:curb][:cross_host]
           kvs.merge! traceview_collect
 
-          TraceView::API.log_entry('curb', kvs)
+          TraceView::API.log_entry(:curb, kvs)
           kvs.clear
 
           if handle_cross_host && !kvs[:blacklisted]
@@ -71,7 +71,7 @@ module TraceView
           response = self.send(method, *args, &block)
 
           if handle_cross_host
-            kvs['HTTPStatus'] = response_code
+            kvs[:HTTPStatus] = response_code
 
             # If we get a redirect, report the location header
             if ((300..308).to_a.include? response_code) && headers.key?("Location")
@@ -92,10 +92,10 @@ module TraceView
 
           response
         rescue => e
-          TraceView::API.log_exception('curb', e)
+          TraceView::API.log_exception(:curb, e)
           raise e
         ensure
-          TraceView::API.log_exit('curb', kvs)
+          TraceView::API.log_exit(:curb, kvs)
         end
 
       end
@@ -120,7 +120,7 @@ module TraceView
       #
       def http_post_with_traceview(*args, &block)
         # If we're not tracing, just do a fast return.
-        if !TraceView.tracing? || TraceView.tracing_layer?('curb')
+        if !TraceView.tracing? || TraceView.tracing_layer?(:curb)
           return http_post_without_traceview(*args)
         end
 
@@ -139,7 +139,7 @@ module TraceView
       #
       def http_put_with_traceview(*args, &block)
         # If we're not tracing, just do a fast return.
-        if !TraceView.tracing? || TraceView.tracing_layer?('curb')
+        if !TraceView.tracing? || TraceView.tracing_layer?(:curb)
           return http_put_without_traceview(data)
         end
 
@@ -158,7 +158,7 @@ module TraceView
       #
       def perform_with_traceview(&block)
         # If we're not tracing, just do a fast return.
-        if !TraceView.tracing? || TraceView.tracing_layer?('curb')
+        if !TraceView.tracing? || TraceView.tracing_layer?(:curb)
           return perform_without_traceview(&block)
         end
 
@@ -219,17 +219,17 @@ module TraceView
 
         begin
           kvs = {}
-          kvs['Backtrace'] = TraceView::API.backtrace if TraceView::Config[:curb][:collect_backtraces]
+          kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:curb][:collect_backtraces]
 
-          TraceView::API.log_entry('curb_multi', kvs)
+          TraceView::API.log_entry(:curb_multi, kvs)
 
           # The core curb call
           http_without_traceview(urls_with_config, multi_options, &block)
         rescue => e
-          TraceView::API.log_exception('curb_multi', e)
+          TraceView::API.log_exception(:curb_multi, e)
           raise e
         ensure
-          TraceView::API.log_exit('curb_multi')
+          TraceView::API.log_exit(:curb_multi)
         end
       end
     end
@@ -252,23 +252,23 @@ module TraceView
       #
       def perform_with_traceview(&block)
         # If we're not tracing or we're not already tracing curb, just do a fast return.
-        if !TraceView.tracing? || ['curb', 'curb_multi'].include?(TraceView.layer)
+        if !TraceView.tracing? || [:curb, :curb_multi].include?(TraceView.layer)
           return perform_without_traceview(&block)
         end
 
         begin
           kvs = {}
-          kvs['Backtrace'] = TraceView::API.backtrace if TraceView::Config[:curb][:collect_backtraces]
+          kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:curb][:collect_backtraces]
 
-          TraceView::API.log_entry('curb_multi', kvs)
+          TraceView::API.log_entry(:curb_multi, kvs)
 
           # The core curb call
           perform_without_traceview(&block)
         rescue => e
-          TraceView::API.log_exception('curb_multi', e)
+          TraceView::API.log_exception(:curb_multi, e)
           raise e
         ensure
-          TraceView::API.log_exit('curb_multi')
+          TraceView::API.log_exit(:curb_multi)
         end
       end
     end

--- a/lib/traceview/inst/curb.rb
+++ b/lib/traceview/inst/curb.rb
@@ -75,7 +75,7 @@ module TraceView
 
             # If we get a redirect, report the location header
             if ((300..308).to_a.include? response_code) && headers.key?("Location")
-              kvs["Location"] = headers["Location"]
+              kvs[:Location] = headers["Location"]
             end
 
             # Curb only provides a single long string of all response headers (yuck!).  So we are forced

--- a/lib/traceview/inst/dalli.rb
+++ b/lib/traceview/inst/dalli.rb
@@ -33,7 +33,7 @@ module TraceView
         end
 
         if TraceView.tracing? && !TraceView.tracing_layer_op?(:get_multi)
-          TraceView::API.trace('memcache', report_kvs) do
+          TraceView::API.trace(:memcache, report_kvs) do
             result = perform_without_traceview(*all_args, &blk)
 
             # Clear the hash for a potential info event
@@ -41,7 +41,7 @@ module TraceView
             report_kvs[:KVHit] = memcache_hit?(result) if op == :get && key.class == String
             report_kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:dalli][:collect_backtraces]
 
-            TraceView::API.log('memcache', 'info', report_kvs) unless report_kvs.empty?
+            TraceView::API.log(:memcache, :info, report_kvs) unless report_kvs.empty?
             result
           end
         else
@@ -64,12 +64,12 @@ module TraceView
           TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
         end
 
-        TraceView::API.trace('memcache', { :KVOp => :get_multi }, :get_multi) do
+        TraceView::API.trace(:memcache, { :KVOp => :get_multi }, :get_multi) do
           values = get_multi_without_traceview(*keys)
 
           info_kvs[:KVHitCount] = values.length
           info_kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:dalli][:collect_backtraces]
-          TraceView::API.log('memcache', 'info', info_kvs)
+          TraceView::API.log(:memcache, :info, info_kvs)
 
           values
         end

--- a/lib/traceview/inst/delayed_job.rb
+++ b/lib/traceview/inst/delayed_job.rb
@@ -44,9 +44,9 @@ if defined?(::Delayed)
                   report_kvs[:JobName] = job.name
                   report_kvs[:MsgID] = job.id
                   report_kvs[:Queue] = job.queue if job.queue
-                  report_kvs['Backtrace'] = TV::API.backtrace if TV::Config[:delayed_jobclient][:collect_backtraces]
+                  report_kvs[:Backtrace] = TV::API.backtrace if TV::Config[:delayed_jobclient][:collect_backtraces]
 
-                  TraceView::API.trace('delayed_job-client', report_kvs) do
+                  TraceView::API.trace(:'delayed_job-client', report_kvs) do
                     block.call(job)
                   end
                 end
@@ -63,7 +63,7 @@ if defined?(::Delayed)
                   report_kvs[:JobName] = job.name
                   report_kvs[:MsgID] = job.id
                   report_kvs[:Queue] = job.queue if job.queue
-                  report_kvs['Backtrace'] = TV::API.backtrace if TV::Config[:delayed_jobworker][:collect_backtraces]
+                  report_kvs[:Backtrace] = TV::API.backtrace if TV::Config[:delayed_jobworker][:collect_backtraces]
 
                   # DelayedJob Specific KVs
                   report_kvs[:priority] = job.priority
@@ -73,7 +73,7 @@ if defined?(::Delayed)
                   TV.logger.warn "[traceview/warning] inst/delayed_job.rb: #{e.message}"
                 end
 
-                result = TraceView::API.start_trace('delayed_job-worker', nil, report_kvs) do
+                result = TraceView::API.start_trace(:'delayed_job-worker', nil, report_kvs) do
                   block.call(worker, job)
                   TV::API.log_exception(nil, job.error) if job.error
                 end

--- a/lib/traceview/inst/em-http-request.rb
+++ b/lib/traceview/inst/em-http-request.rb
@@ -11,10 +11,10 @@ module TraceView
           blacklisted = TraceView::API.blacklisted?(@uri)
 
           begin
-            report_kvs['IsService'] = 1
-            report_kvs['RemoteURL'] = @uri
-            report_kvs['HTTPMethod'] = args[0]
-            report_kvs['Blacklisted'] = true if blacklisted
+            report_kvs[:IsService] = 1
+            report_kvs[:RemoteURL] = @uri
+            report_kvs[:HTTPMethod] = args[0]
+            report_kvs[:Blacklisted] = true if blacklisted
 
             if TraceView::Config[:em_http_request][:collect_backtraces]
               report_kvs[:Backtrace] = TraceView::API.backtrace
@@ -23,7 +23,7 @@ module TraceView
             TraceView.logger.debug "[traceview/debug] em-http-request KV error: #{e.inspect}"
           end
 
-          ::TraceView::API.log_entry('em-http-request', report_kvs)
+          ::TraceView::API.log_entry(:'em-http-request', report_kvs)
           client = setup_request_without_traceview(*args, &block)
           client.req.headers['X-Trace'] = context unless blacklisted
           client
@@ -66,7 +66,7 @@ module TraceView
 
           end
 
-          ::TraceView::API.log_exit('em-http-request', report_kvs)
+          ::TraceView::API.log_exit(:'em-http-request', report_kvs)
         end
       end
     end

--- a/lib/traceview/inst/faraday.rb
+++ b/lib/traceview/inst/faraday.rb
@@ -13,13 +13,13 @@ module TraceView
         # Otherwise, the Net::HTTP instrumentation will send the service KVs
         handle_service = !@builder.handlers.include?(Faraday::Adapter::NetHttp) &&
                          !@builder.handlers.include?(Faraday::Adapter::Excon)
-        TraceView::API.log_entry('faraday')
+        TraceView::API.log_entry(:faraday)
 
         result = run_request_without_traceview(method, url, body, headers, &block)
 
         kvs = {}
-        kvs['Middleware'] = @builder.handlers
-        kvs['Backtrace'] = TraceView::API.backtrace if TraceView::Config[:faraday][:collect_backtraces]
+        kvs[:Middleware] = @builder.handlers
+        kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:faraday][:collect_backtraces]
 
         if handle_service
           blacklisted = TraceView::API.blacklisted?(@url_prefix.to_s)
@@ -30,14 +30,14 @@ module TraceView
           # Conditionally add the X-Trace header to the outgoing request
           @headers['X-Trace'] = context unless blacklisted
 
-          kvs['IsService'] = 1
-          kvs['RemoteProtocol'] = (@url_prefix.scheme == 'https') ? 'HTTPS' : 'HTTP'
-          kvs['RemoteHost'] = @url_prefix.host
-          kvs['RemotePort'] = @url_prefix.port
-          kvs['ServiceArg'] = url
-          kvs['HTTPMethod'] = method
+          kvs[:IsService] = 1
+          kvs[:RemoteProtocol] = (@url_prefix.scheme == 'https') ? 'HTTPS' : 'HTTP'
+          kvs[:RemoteHost] = @url_prefix.host
+          kvs[:RemotePort] = @url_prefix.port
+          kvs[:ServiceArg] = url
+          kvs[:HTTPMethod] = method
           kvs[:HTTPStatus] = result.status
-          kvs['Blacklisted'] = true if blacklisted
+          kvs[:Blacklisted] = true if blacklisted
 
           # Re-attach net::http edge unless it's blacklisted or if we don't have a
           # valid X-Trace header
@@ -56,13 +56,13 @@ module TraceView
           end
         end
 
-        TraceView::API.log('faraday', 'info', kvs)
+        TraceView::API.log(:faraday, :info, kvs)
         result
       rescue => e
-        TraceView::API.log_exception('faraday', e)
+        TraceView::API.log_exception(:faraday, e)
         raise e
       ensure
-        TraceView::API.log_exit('faraday')
+        TraceView::API.log_exit(:faraday)
       end
     end
   end

--- a/lib/traceview/inst/http.rb
+++ b/lib/traceview/inst/http.rb
@@ -68,7 +68,7 @@ if TraceView::Config[:nethttp][:enabled]
 
           # If we get a redirect, report the location header
           if ((300..308).to_a.include? resp.code.to_i) && resp.header["Location"]
-            opts["Location"] = resp.header["Location"]
+            opts[:Location] = resp.header["Location"]
           end
 
           next resp

--- a/lib/traceview/inst/http.rb
+++ b/lib/traceview/inst/http.rb
@@ -17,7 +17,7 @@ if TraceView::Config[:nethttp][:enabled]
       # Avoid cross host tracing for blacklisted domains
       blacklisted = TraceView::API.blacklisted?(addr_port)
 
-      TraceView::API.trace('net-http') do
+      TraceView::API.trace(:'net-http') do
         opts = {}
         context = TraceView::Context.toString()
         task_id = TraceView::XTrace.task_id(context)
@@ -26,20 +26,20 @@ if TraceView::Config[:nethttp][:enabled]
         if args.length && args[0]
           req = args[0]
 
-          opts['IsService'] = 1
-          opts['RemoteProtocol'] = use_ssl? ? 'HTTPS' : 'HTTP'
-          opts['RemoteHost'] = addr_port
+          opts[:IsService] = 1
+          opts[:RemoteProtocol] = use_ssl? ? :HTTPS : :HTTP
+          opts[:RemoteHost] = addr_port
 
           # Conditionally log query params
           if TraceView::Config[:nethttp][:log_args]
-            opts['ServiceArg'] = req.path
+            opts[:ServiceArg] = req.path
           else
-            opts['ServiceArg'] = req.path.split('?').first
+            opts[:ServiceArg] = req.path.split('?').first
           end
 
-          opts['HTTPMethod'] = req.method
-          opts['Blacklisted'] = true if blacklisted
-          opts['Backtrace'] = TraceView::API.backtrace if TraceView::Config[:nethttp][:collect_backtraces]
+          opts[:HTTPMethod] = req.method
+          opts[:Blacklisted] = true if blacklisted
+          opts[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:nethttp][:collect_backtraces]
 
           req['X-Trace'] = context unless blacklisted
         end
@@ -64,7 +64,7 @@ if TraceView::Config[:nethttp][:enabled]
             end
           end
 
-          opts['HTTPStatus'] = resp.code
+          opts[:HTTPStatus] = resp.code
 
           # If we get a redirect, report the location header
           if ((300..308).to_a.include? resp.code.to_i) && resp.header["Location"]
@@ -74,7 +74,7 @@ if TraceView::Config[:nethttp][:enabled]
           next resp
         ensure
           # Log the info event with the KVs in opts
-          TraceView::API.log('net-http', 'info', opts)
+          TraceView::API.log(:'net-http', :info, opts)
         end
       end
     end

--- a/lib/traceview/inst/httpclient.rb
+++ b/lib/traceview/inst/httpclient.rb
@@ -147,7 +147,7 @@ module TraceView
 
           # If we get a redirect, report the location header
           if ((300..308).to_a.include? response.status.to_i) && response.headers.key?("Location")
-            kvs["Location"] = response.headers["Location"]
+            kvs[:Location] = response.headers["Location"]
           end
 
           if response_context && !blacklisted

--- a/lib/traceview/inst/httpclient.rb
+++ b/lib/traceview/inst/httpclient.rb
@@ -12,23 +12,23 @@ module TraceView
 
       def traceview_collect(method, uri, query = nil)
         kvs = {}
-        kvs['IsService'] = 1
+        kvs[:IsService] = 1
 
         # Conditionally log URL query params
         # Because of the hook points, the query arg can come in under <tt>query</tt>
         # or as a part of <tt>uri</tt> (not both).  Here we handle both cases.
         if TraceView::Config[:httpclient][:log_args]
           if query
-            kvs['RemoteURL'] = uri.to_s + '?' + TraceView::Util.to_query(query)
+            kvs[:RemoteURL] = uri.to_s + '?' + TraceView::Util.to_query(query)
           else
-            kvs['RemoteURL'] = uri.to_s
+            kvs[:RemoteURL] = uri.to_s
           end
         else
-          kvs['RemoteURL'] = uri.to_s.split('?').first
+          kvs[:RemoteURL] = uri.to_s.split('?').first
         end
 
-        kvs['HTTPMethod'] = ::TraceView::Util.upcase(method)
-        kvs['Backtrace'] = TraceView::API.backtrace if TraceView::Config[:httpclient][:collect_backtraces]
+        kvs[:HTTPMethod] = ::TraceView::Util.upcase(method)
+        kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:httpclient][:collect_backtraces]
         kvs
       rescue => e
         TraceView.logger.debug "[traceview/debug] Error capturing httpclient KVs: #{e.message}"
@@ -50,9 +50,9 @@ module TraceView
           blacklisted = TraceView::API.blacklisted?(uri.hostname)
 
           kvs = traceview_collect(method, uri, query)
-          kvs['Blacklisted'] = true if blacklisted
+          kvs[:Blacklisted] = true if blacklisted
 
-          TraceView::API.log_entry('httpclient', kvs)
+          TraceView::API.log_entry(:httpclient, kvs)
           kvs.clear
 
           req_context = TraceView::Context.toString()
@@ -68,11 +68,11 @@ module TraceView
           response = do_request_without_traceview(method, uri, query, body, header, &block)
 
           response_context = response.headers['X-Trace']
-          kvs['HTTPStatus'] = response.status_code
+          kvs[:HTTPStatus] = response.status_code
 
           # If we get a redirect, report the location header
           if ((300..308).to_a.include? response.status.to_i) && response.headers.key?("Location")
-            kvs["Location"] = response.headers["Location"]
+            kvs[:Location] = response.headers["Location"]
           end
 
           if response_context && !blacklisted
@@ -81,10 +81,10 @@ module TraceView
 
           response
         rescue => e
-          TraceView::API.log_exception('httpclient', e)
+          TraceView::API.log_exception(:httpclient, e)
           raise e
         ensure
-          TraceView::API.log_exit('httpclient', kvs)
+          TraceView::API.log_exit(:httpclient, kvs)
         end
       end
 
@@ -123,10 +123,10 @@ module TraceView
           blacklisted = TraceView::API.blacklisted?(uri.hostname)
 
           kvs = traceview_collect(method, uri)
-          kvs['Blacklisted'] = true if blacklisted
-          kvs['Async'] = 1
+          kvs[:Blacklisted] = true if blacklisted
+          kvs[:Async] = 1
 
-          TraceView::API.log_entry('httpclient', kvs)
+          TraceView::API.log_entry(:httpclient, kvs)
           kvs.clear
 
           req_context = TraceView::Context.toString()
@@ -143,7 +143,7 @@ module TraceView
           end
 
           response_context = response.headers['X-Trace']
-          kvs['HTTPStatus'] = response.status_code
+          kvs[:HTTPStatus] = response.status_code
 
           # If we get a redirect, report the location header
           if ((300..308).to_a.include? response.status.to_i) && response.headers.key?("Location")
@@ -158,11 +158,11 @@ module TraceView
           conn.push response if result.is_a?(::HTTPClient::Connection)
           result
         rescue => e
-          TraceView::API.log_exception('httpclient', e)
+          TraceView::API.log_exception(:httpclient, e)
           raise e
         ensure
           # TraceView::API.log_exit('httpclient', kvs.merge('Async' => 1))
-          TraceView::API.log_exit('httpclient', kvs)
+          TraceView::API.log_exit(:httpclient, kvs)
         end
       end
     end

--- a/lib/traceview/inst/memcache.rb
+++ b/lib/traceview/inst/memcache.rb
@@ -17,7 +17,7 @@ module TraceView
               report_kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:memcache][:collect_backtraces]
 
               if TraceView.tracing?
-                TraceView::API.trace('memcache', report_kvs) do
+                TraceView::API.trace(:memcache, report_kvs) do
                   send("#{m}_without_traceview", *args)
                 end
               else
@@ -58,11 +58,11 @@ module TraceView
           TraceView.logger.debug e.backtrace
         end
 
-        TraceView::API.trace('memcache', { :KVOp => :get_multi }, :get_multi) do
+        TraceView::API.trace(:memcache, { :KVOp => :get_multi }, :get_multi) do
           values = get_multi_without_traceview(args)
 
           info_kvs[:KVHitCount] = values.length
-          TraceView::API.log('memcache', 'info', info_kvs)
+          TraceView::API.log(:memcache, :info, info_kvs)
 
           values
         end
@@ -74,7 +74,7 @@ module TraceView
 
           info_kvs = { :KVKey => cache_key, :RemoteHost => server.host }
           info_kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:memcache][:collect_backtraces]
-          TraceView::API.log('memcache', 'info', info_kvs)
+          TraceView::API.log(:memcache, :info, info_kvs)
 
           [server, cache_key]
         else
@@ -87,7 +87,7 @@ module TraceView
 
         info_kvs = { :KVHit => memcache_hit?(result) }
         info_kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:memcache][:collect_backtraces]
-        TraceView::API.log('memcache', 'info', info_kvs)
+        TraceView::API.log(:memcache, :info, info_kvs)
 
         result
       end

--- a/lib/traceview/inst/memcached.rb
+++ b/lib/traceview/inst/memcached.rb
@@ -20,14 +20,14 @@ module TraceView
                 opts[:RemoteHost] = rhost if rhost
               end
 
-              TraceView::API.trace('memcache', opts) do
+              TraceView::API.trace(:memcache, opts) do
                 result = send("#{m}_without_traceview", *args)
 
                 info_kvs = {}
                 info_kvs[:KVHit] = memcache_hit?(result) if m == :get && args.length && args[0].class == String
                 info_kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:memcached][:collect_backtraces]
 
-                TraceView::API.log('memcache', 'info', info_kvs) unless info_kvs.empty?
+                TraceView::API.log(:memcache, :info, info_kvs) unless info_kvs.empty?
                 result
               end
             end
@@ -57,7 +57,7 @@ module TraceView
           layer_kvs = {}
           layer_kvs[:KVOp] = :get_multi
 
-          TraceView::API.trace('memcache', layer_kvs || {}, :get_multi) do
+          TraceView::API.trace(:memcache, layer_kvs || {}, :get_multi) do
             begin
               info_kvs = {}
               info_kvs[:KVKeyCount] = keys.flatten.length
@@ -67,7 +67,7 @@ module TraceView
               info_kvs[:KVHitCount] = values.length
               info_kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:memcached][:collect_backtraces]
 
-              TraceView::API.log('memcache', 'info', info_kvs)
+              TraceView::API.log(:memcache, :info, info_kvs)
             rescue
               values = get_multi_without_traceview(keys, raw)
             end

--- a/lib/traceview/inst/mongo.rb
+++ b/lib/traceview/inst/mongo.rb
@@ -60,7 +60,7 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Tr
               TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
             end
 
-            TraceView::API.trace('mongo', report_kvs) do
+            TraceView::API.trace(:mongo, report_kvs) do
               send("#{m}_without_traceview", *args)
             end
           end
@@ -94,7 +94,7 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Tr
                 unless @selector.empty?
                   report_kvs[:Query] = @selector.to_json
                 else
-                  report_kvs[:Query] = 'all'
+                  report_kvs[:Query] = :all
                 end
                 report_kvs[:Limit] = @limit if @limit != 0
               end
@@ -102,7 +102,7 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Tr
               TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
             end
 
-            TraceView::API.trace('mongo', report_kvs) do
+            TraceView::API.trace(:mongo, report_kvs) do
               send("#{m}_without_traceview", *args)
             end
           end
@@ -167,7 +167,7 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Tr
               TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
             end
 
-            TraceView::API.trace('mongo', report_kvs) do
+            TraceView::API.trace(:mongo, report_kvs) do
               send("#{m}_without_traceview", *args)
             end
           end
@@ -206,7 +206,7 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Tr
               TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
             end
 
-            TraceView::API.trace('mongo', report_kvs) do
+            TraceView::API.trace(:mongo, report_kvs) do
               send("#{m}_without_traceview", *args, &blk)
             end
           end
@@ -228,7 +228,7 @@ if defined?(::Mongo) && (Gem.loaded_specs['mongo'].version.to_s < '2.0.0') && Tr
               TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
             end
 
-            TraceView::API.trace('mongo', report_kvs) do
+            TraceView::API.trace(:mongo, report_kvs) do
               send("#{m}_without_traceview", *args)
             end
           end

--- a/lib/traceview/inst/moped.rb
+++ b/lib/traceview/inst/moped.rb
@@ -6,7 +6,7 @@ require 'json'
 module TraceView
   module Inst
     module Moped
-      FLAVOR = 'mongodb'
+      FLAVOR = :mongodb
 
       # Moped::Database
       DB_OPS         = [:command, :drop]
@@ -62,7 +62,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
               TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
             end
 
-            TraceView::API.trace('mongo', report_kvs) do
+            TraceView::API.trace(:mongo, report_kvs) do
               command_without_traceview(command)
             end
           else
@@ -75,7 +75,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
 
           report_kvs = extract_trace_details(:drop_database)
 
-          TraceView::API.trace('mongo', report_kvs) do
+          TraceView::API.trace(:mongo, report_kvs) do
             drop_without_traceview
           end
         end
@@ -130,7 +130,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
             TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
           end
 
-          TraceView::API.trace('mongo', report_kvs, :create_index) do
+          TraceView::API.trace(:mongo, report_kvs, :create_index) do
             create_without_traceview(key, options = {})
           end
         end
@@ -142,12 +142,12 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
             # We report :drop_indexes here to be consistent
             # with other mongo implementations
             report_kvs = extract_trace_details(:drop_indexes)
-            report_kvs[:Key] = key.nil? ? 'all' : key.to_json
+            report_kvs[:Key] = key.nil? ? :all : key.to_json
           rescue StandardError => e
             TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
           end
 
-          TraceView::API.trace('mongo', report_kvs) do
+          TraceView::API.trace(:mongo, report_kvs) do
             drop_without_traceview(key = nil)
           end
         end
@@ -194,12 +194,12 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
 
           begin
             report_kvs = extract_trace_details(:count)
-            report_kvs[:Query] = selector.empty? ? 'all' : selector.to_json
+            report_kvs[:Query] = selector.empty? ? :all : selector.to_json
           rescue StandardError => e
             TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
           end
 
-          TraceView::API.trace('mongo', report_kvs) do
+          TraceView::API.trace(:mongo, report_kvs) do
             count_without_traceview
           end
         end
@@ -209,13 +209,13 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
 
           begin
             report_kvs = extract_trace_details(:sort)
-            report_kvs[:Query] = selector.empty? ? 'all' : selector.to_json
+            report_kvs[:Query] = selector.empty? ? :all : selector.to_json
             report_kvs[:Order] = sort.to_s
           rescue StandardError => e
             TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
           end
 
-          TraceView::API.trace('mongo', report_kvs) do
+          TraceView::API.trace(:mongo, report_kvs) do
             sort_without_traceview(sort)
           end
         end
@@ -224,13 +224,13 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
           if TraceView.tracing? && !TraceView.tracing_layer_op?(:explain)
             begin
               report_kvs = extract_trace_details(:limit)
-              report_kvs[:Query] = selector.empty? ? 'all' : selector.to_json
+              report_kvs[:Query] = selector.empty? ? :all : selector.to_json
               report_kvs[:Limit] = limit.to_s
             rescue StandardError => e
               TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
             end
 
-            TraceView::API.trace('mongo', report_kvs) do
+            TraceView::API.trace(:mongo, report_kvs) do
               limit_without_traceview(limit)
             end
           else
@@ -243,13 +243,13 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
 
           begin
             report_kvs = extract_trace_details(:distinct)
-            report_kvs[:Query] = selector.empty? ? 'all' : selector.to_json
+            report_kvs[:Query] = selector.empty? ? :all : selector.to_json
             report_kvs[:Key] = key.to_s
           rescue StandardError => e
             TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
           end
 
-          TraceView::API.trace('mongo', report_kvs) do
+          TraceView::API.trace(:mongo, report_kvs) do
             distinct_without_traceview(key)
           end
         end
@@ -264,7 +264,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
               TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
             end
 
-            TraceView::API.trace('mongo', report_kvs) do
+            TraceView::API.trace(:mongo, report_kvs) do
               update_without_traceview(change, flags)
             end
           else
@@ -282,7 +282,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
             TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
           end
 
-          TraceView::API.trace('mongo', report_kvs, :update_all) do
+          TraceView::API.trace(:mongo, report_kvs, :update_all) do
             update_all_without_traceview(change)
           end
         end
@@ -298,7 +298,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
             TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
           end
 
-          TraceView::API.trace('mongo', report_kvs, :upsert) do
+          TraceView::API.trace(:mongo, report_kvs, :upsert) do
             upsert_without_traceview(change)
           end
         end
@@ -308,12 +308,12 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
 
           begin
             report_kvs = extract_trace_details(:explain)
-            report_kvs[:Query] = selector.empty? ? 'all' : selector.to_json
+            report_kvs[:Query] = selector.empty? ? :all : selector.to_json
           rescue StandardError => e
             TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
           end
 
-          TraceView::API.trace('mongo', report_kvs, :explain) do
+          TraceView::API.trace(:mongo, report_kvs, :explain) do
             explain_without_traceview
           end
         end
@@ -323,14 +323,14 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
 
           begin
             report_kvs = extract_trace_details(:modify)
-            report_kvs[:Update_Document] = selector.empty? ? 'all' : selector.to_json
+            report_kvs[:Update_Document] = selector.empty? ? :all : selector.to_json
             report_kvs[:Change] = change.to_json
             report_kvs[:Options] = options.to_json
           rescue StandardError => e
             TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
           end
 
-          TraceView::API.trace('mongo', report_kvs) do
+          TraceView::API.trace(:mongo, report_kvs) do
             modify_without_traceview(change, options)
           end
         end
@@ -345,7 +345,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
             TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
           end
 
-          TraceView::API.trace('mongo', report_kvs) do
+          TraceView::API.trace(:mongo, report_kvs) do
             remove_without_traceview
           end
         end
@@ -360,7 +360,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
             TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
           end
 
-          TraceView::API.trace('mongo', report_kvs) do
+          TraceView::API.trace(:mongo, report_kvs) do
             remove_all_without_traceview
           end
         end
@@ -409,7 +409,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
           # with other mongo implementations
           report_kvs = extract_trace_details(:drop_collection)
 
-          TraceView::API.trace('mongo', report_kvs) do
+          TraceView::API.trace(:mongo, report_kvs) do
             drop_without_traceview
           end
         end
@@ -424,7 +424,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
             TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
           end
 
-          TraceView::API.trace('mongo', report_kvs) do
+          TraceView::API.trace(:mongo, report_kvs) do
             find_without_traceview(selector)
           end
         end
@@ -434,7 +434,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
 
           report_kvs = extract_trace_details(:indexes)
 
-          TraceView::API.trace('mongo', report_kvs) do
+          TraceView::API.trace(:mongo, report_kvs) do
             indexes_without_traceview
           end
         end
@@ -443,7 +443,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
           if TraceView.tracing? && !TraceView.tracing_layer_op?(:create_index)
             report_kvs = extract_trace_details(:insert)
 
-            TraceView::API.trace('mongo', report_kvs) do
+            TraceView::API.trace(:mongo, report_kvs) do
               insert_without_traceview(documents, flags)
             end
           else
@@ -457,7 +457,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
           report_kvs = extract_trace_details(:aggregate)
           report_kvs[:Query] = pipeline
 
-          TraceView::API.trace('mongo', report_kvs) do
+          TraceView::API.trace(:mongo, report_kvs) do
             aggregate_without_traceview(pipeline)
           end
         end

--- a/lib/traceview/inst/rack.rb
+++ b/lib/traceview/inst/rack.rb
@@ -72,7 +72,7 @@ module TraceView
       end
 
       # Detect and log AVW headers for sampling analysis
-      report_kvs[:'X-TV-Meta'] = env['HTTP_X_TV_META'] if env.key?('HTTP_X_TV_META')
+      report_kvs['X-TV-Meta'] = env['HTTP_X_TV_META'] if env.key?('HTTP_X_TV_META')
 
       # Check for and validate X-Trace request header to pick up tracing context
       xtrace = env.is_a?(Hash) ? env['HTTP_X_TRACE'] : nil

--- a/lib/traceview/inst/redis.rb
+++ b/lib/traceview/inst/redis.rb
@@ -222,17 +222,17 @@ module TraceView
         #
         def call_with_traceview(command, &block)
           if TraceView.tracing?
-            ::TraceView::API.log_entry('redis', {})
+            ::TraceView::API.log_entry(:redis, {})
 
             begin
               r = call_without_traceview(command, &block)
               report_kvs = extract_trace_details(command, r)
               r
             rescue StandardError => e
-              ::TraceView::API.log_exception('redis', e)
+              ::TraceView::API.log_exception(:redis, e)
               raise
             ensure
-              ::TraceView::API.log_exit('redis', report_kvs)
+              ::TraceView::API.log_exit(:redis, report_kvs)
             end
 
           else
@@ -250,17 +250,17 @@ module TraceView
             # back on exit (a limitation of the TraceView::API.trace
             # block method)  This removes the need for an info
             # event to send additonal KVs
-            ::TraceView::API.log_entry('redis', {})
+            ::TraceView::API.log_entry(:redis, {})
 
             report_kvs = extract_pipeline_details(pipeline)
 
             begin
               call_pipeline_without_traceview(pipeline)
             rescue StandardError => e
-              ::TraceView::API.log_exception('redis', e)
+              ::TraceView::API.log_exception(:redis, e)
               raise
             ensure
-              ::TraceView::API.log_exit('redis', report_kvs)
+              ::TraceView::API.log_exit(:redis, report_kvs)
             end
           else
             call_pipeline_without_traceview(pipeline)

--- a/lib/traceview/inst/resque.rb
+++ b/lib/traceview/inst/resque.rb
@@ -45,7 +45,7 @@ module TraceView
         if TraceView.tracing?
           report_kvs = extract_trace_details(:enqueue, klass, args)
 
-          TraceView::API.trace('resque-client', report_kvs, :enqueue) do
+          TraceView::API.trace(:'resque-client', report_kvs, :enqueue) do
             enqueue_without_traceview(klass, *args)
           end
         else
@@ -58,7 +58,7 @@ module TraceView
           report_kvs = extract_trace_details(:enqueue_to, klass, args)
           report_kvs[:Queue] = queue.to_s if queue
 
-          TraceView::API.trace('resque-client', report_kvs) do
+          TraceView::API.trace(:'resque-client', report_kvs) do
             enqueue_to_without_traceview(queue, klass, *args)
           end
         else
@@ -70,7 +70,7 @@ module TraceView
         if TraceView.tracing?
           report_kvs = extract_trace_details(:dequeue, klass, args)
 
-          TraceView::API.trace('resque-client', report_kvs) do
+          TraceView::API.trace(:'resque-client', report_kvs) do
             dequeue_without_traceview(klass, *args)
           end
         else
@@ -96,7 +96,7 @@ module TraceView
           # Set these keys for the ability to separate out
           # background tasks into a separate app on the server-side UI
 
-          report_kvs['HTTP-Host'] = Socket.gethostname
+          report_kvs[:'HTTP-Host'] = Socket.gethostname
           report_kvs[:Controller] = "Resque_#{job.queue}"
           report_kvs[:Action] = job.payload['class'].to_s
           report_kvs[:URL] = "/resque/#{job.queue}/#{job.payload['class']}"
@@ -117,7 +117,7 @@ module TraceView
           TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
         end
 
-        TraceView::API.start_trace('resque-worker', nil, report_kvs) do
+        TraceView::API.start_trace(:'resque-worker', nil, report_kvs) do
           perform_without_traceview(job)
         end
       end
@@ -130,7 +130,7 @@ module TraceView
 
       def fail_with_traceview(exception)
         if TraceView.tracing?
-          TraceView::API.log_exception('resque', exception)
+          TraceView::API.log_exception(:resque, exception)
         end
         fail_without_traceview(exception)
       end

--- a/lib/traceview/inst/rest-client.rb
+++ b/lib/traceview/inst/rest-client.rb
@@ -15,16 +15,16 @@ module TraceView
       #
       def execute_with_traceview & block
         kvs = {}
-        kvs['Backtrace'] = TraceView::API.backtrace if TraceView::Config[:rest_client][:collect_backtraces]
-        TraceView::API.log_entry('rest-client', kvs)
+        kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:rest_client][:collect_backtraces]
+        TraceView::API.log_entry(:'rest-client', kvs)
 
         # The core rest-client call
         execute_without_traceview(&block)
       rescue => e
-        TraceView::API.log_exception('rest-client', e)
+        TraceView::API.log_exception(:'rest-client', e)
         raise e
       ensure
-        TraceView::API.log_exit('rest-client')
+        TraceView::API.log_exit(:'rest-client')
       end
     end
   end

--- a/lib/traceview/inst/sequel.rb
+++ b/lib/traceview/inst/sequel.rb
@@ -53,33 +53,33 @@ module TraceView
       def run_with_traceview(sql, opts=::Sequel::OPTS)
         kvs = extract_trace_details(sql, opts)
 
-        TraceView::API.log_entry('sequel', kvs)
+        TraceView::API.log_entry(:sequel, kvs)
 
         run_without_traceview(sql, opts)
       rescue => e
-        TraceView::API.log_exception('sequel', e)
+        TraceView::API.log_exception(:sequel, e)
         raise e
       ensure
-        TraceView::API.log_exit('sequel')
+        TraceView::API.log_exit(:sequel)
       end
 
       def exec_with_traceview(method, sql, opts=::Sequel::OPTS, &block)
         kvs = extract_trace_details(sql, opts)
 
-        TraceView::API.log_entry('sequel', kvs)
+        TraceView::API.log_entry(:sequel, kvs)
 
         send(method, sql, opts, &block)
       rescue => e
-        TraceView::API.log_exception('sequel', e)
+        TraceView::API.log_exception(:sequel, e)
         raise e
       ensure
-        TraceView::API.log_exit('sequel')
+        TraceView::API.log_exit(:sequel)
       end
 
       def execute_ddl_with_traceview(sql, opts=::Sequel::OPTS, &block)
         # If we're already tracing a sequel operation, then this call likely came
         # from Sequel::Dataset.  In this case, just pass it on.
-        return execute_ddl_without_traceview(sql, opts, &block) if TraceView.tracing_layer?('sequel')
+        return execute_ddl_without_traceview(sql, opts, &block) if TraceView.tracing_layer?(:sequel)
 
         exec_with_traceview(:execute_ddl_without_traceview, sql, opts, &block)
       end
@@ -87,7 +87,7 @@ module TraceView
       def execute_dui_with_traceview(sql, opts=::Sequel::OPTS, &block)
         # If we're already tracing a sequel operation, then this call likely came
         # from Sequel::Dataset.  In this case, just pass it on.
-        return execute_dui_without_traceview(sql, opts, &block) if TraceView.tracing_layer?('sequel')
+        return execute_dui_without_traceview(sql, opts, &block) if TraceView.tracing_layer?(:sequel)
 
         exec_with_traceview(:execute_dui_without_traceview, sql, opts, &block)
       end
@@ -95,7 +95,7 @@ module TraceView
       def execute_insert_with_traceview(sql, opts=::Sequel::OPTS, &block)
         # If we're already tracing a sequel operation, then this call likely came
         # from Sequel::Dataset.  In this case, just pass it on.
-        return execute_insert_without_traceview(sql, opts, &block) if TraceView.tracing_layer?('sequel')
+        return execute_insert_without_traceview(sql, opts, &block) if TraceView.tracing_layer?(:sequel)
 
         exec_with_traceview(:execute_insert_without_traceview, sql, opts, &block)
       end
@@ -113,14 +113,14 @@ module TraceView
       def exec_with_traceview(method, sql, opts=::Sequel::OPTS, &block)
         kvs = extract_trace_details(sql, opts)
 
-        TraceView::API.log_entry('sequel', kvs)
+        TraceView::API.log_entry(:sequel, kvs)
 
         send(method, sql, opts, &block)
       rescue => e
-        TraceView::API.log_exception('sequel', e)
+        TraceView::API.log_exception(:sequel, e)
         raise e
       ensure
-        TraceView::API.log_exit('sequel')
+        TraceView::API.log_exit(:sequel)
       end
 
       def execute_with_traceview(sql, opts=::Sequel::OPTS, &block)

--- a/lib/traceview/inst/sidekiq-client.rb
+++ b/lib/traceview/inst/sidekiq-client.rb
@@ -29,7 +29,7 @@ module TraceView
       # args: 0: worker_class, 1: msg, 2: queue, 3: redis_pool
       report_kvs = collect_kvs(args)
 
-      TraceView::API.log_entry('sidekiq-client', report_kvs)
+      TraceView::API.log_entry(:'sidekiq-client', report_kvs)
       args[1]['SourceTrace'] = TraceView::Context.toString if TraceView.tracing?
 
       result = yield
@@ -37,10 +37,10 @@ module TraceView
       report_kvs = { :JobID => result['jid'] }
       result
     rescue => e
-      TraceView::API.log_exception('sidekiq-client', e, report_kvs)
+      TraceView::API.log_exception(:'sidekiq-client', e, report_kvs)
       raise
     ensure
-      TraceView::API.log_exit('sidekiq-client', report_kvs)
+      TraceView::API.log_exit(:'sidekiq-client', report_kvs)
     end
   end
 end

--- a/lib/traceview/inst/sidekiq-worker.rb
+++ b/lib/traceview/inst/sidekiq-worker.rb
@@ -18,10 +18,10 @@ module TraceView
         report_kvs[:JobName]    = worker.class.to_s
         report_kvs[:MsgID]      = msg['jid']
         report_kvs[:Args]       = msg['args'].to_s[0..1024] if TV::Config[:sidekiqworker][:log_args]
-        report_kvs['Backtrace'] = TV::API.backtrace         if TV::Config[:sidekiqworker][:collect_backtraces]
+        report_kvs[:Backtrace]  = TV::API.backtrace         if TV::Config[:sidekiqworker][:collect_backtraces]
 
         # Webserver Spec KVs
-        report_kvs['HTTP-Host'] = Socket.gethostname
+        report_kvs[:'HTTP-Host'] = Socket.gethostname
         report_kvs[:Controller] = "Sidekiq_#{queue}"
         report_kvs[:Action] = msg['class']
         report_kvs[:URL] = "/sidekiq/#{queue}/#{msg['class']}"
@@ -49,7 +49,7 @@ module TraceView
         report_kvs['X-TV-Meta'] = args[1]['SourceTrace']
       end
 
-      result = TraceView::API.start_trace('sidekiq-worker', nil, report_kvs) do
+      result = TraceView::API.start_trace(:'sidekiq-worker', nil, report_kvs) do
         yield
       end
 

--- a/lib/traceview/inst/twitter-cassandra.rb
+++ b/lib/traceview/inst/twitter-cassandra.rb
@@ -48,7 +48,7 @@ module TraceView
 
         report_kvs = extract_trace_details(:insert, column_family, key, hash, options)
 
-        TraceView::API.trace('cassandra', report_kvs) do
+        TraceView::API.trace(:cassandra, report_kvs) do
           insert_without_traceview(column_family, key, hash, options = {})
         end
       end
@@ -59,7 +59,7 @@ module TraceView
         args = [column_family, key] + columns_and_options
         report_kvs = extract_trace_details(:remove, column_family, key, columns_and_options)
 
-        TraceView::API.trace('cassandra', report_kvs) do
+        TraceView::API.trace(:cassandra, report_kvs) do
           send :remove_without_traceview, *args
         end
       end
@@ -70,7 +70,7 @@ module TraceView
         args = [column_family, key] + columns_and_options
         report_kvs = extract_trace_details(:count_columns, column_family, key, columns_and_options)
 
-        TraceView::API.trace('cassandra', report_kvs) do
+        TraceView::API.trace(:cassandra, report_kvs) do
           send :count_columns_without_traceview, *args
         end
       end
@@ -81,7 +81,7 @@ module TraceView
         if TraceView.tracing? && !TraceView.tracing_layer_op?(:multi_get_columns)
           report_kvs = extract_trace_details(:get_columns, column_family, key, columns_and_options)
 
-          TraceView::API.trace('cassandra', report_kvs) do
+          TraceView::API.trace(:cassandra, report_kvs) do
             send :get_columns_without_traceview, *args
           end
         else
@@ -95,7 +95,7 @@ module TraceView
         args = [column_family, key] + columns_and_options
         report_kvs = extract_trace_details(:multi_get_columns, column_family, key, columns_and_options)
 
-        TraceView::API.trace('cassandra', report_kvs, :multi_get_columns) do
+        TraceView::API.trace(:cassandra, report_kvs, :multi_get_columns) do
           send :multi_get_columns_without_traceview, *args
         end
       end
@@ -106,7 +106,7 @@ module TraceView
         args = [column_family, key] + columns_and_options
         report_kvs = extract_trace_details(:get, column_family, key, columns_and_options)
 
-        TraceView::API.trace('cassandra', report_kvs, :get) do
+        TraceView::API.trace(:cassandra, report_kvs, :get) do
           send :get_without_traceview, *args
         end
       end
@@ -117,7 +117,7 @@ module TraceView
         if TraceView.tracing? && !TraceView.tracing_layer_op?(:get)
           report_kvs = extract_trace_details(:multi_get, column_family, key, columns_and_options)
 
-          TraceView::API.trace('cassandra', report_kvs) do
+          TraceView::API.trace(:cassandra, report_kvs) do
             send :multi_get_without_traceview, *args
           end
         else
@@ -131,7 +131,7 @@ module TraceView
         args = [column_family, key] + columns_and_options
         report_kvs = extract_trace_details(:exists?, column_family, key, columns_and_options)
 
-        TraceView::API.trace('cassandra', report_kvs) do
+        TraceView::API.trace(:cassandra, report_kvs) do
           send :exists_without_traceview?, *args
         end
       end
@@ -140,7 +140,7 @@ module TraceView
         if TraceView.tracing? && !TraceView.tracing_layer_op?(:get_range_batch)
           report_kvs = extract_trace_details(:get_range_single, column_family, nil, nil)
 
-          TraceView::API.trace('cassandra', report_kvs) do
+          TraceView::API.trace(:cassandra, report_kvs) do
             get_range_single_without_traceview(column_family, options)
           end
         else
@@ -153,7 +153,7 @@ module TraceView
 
         report_kvs = extract_trace_details(:get_range_batch, column_family, nil, nil)
 
-        TraceView::API.trace('cassandra', report_kvs, :get_range_batch) do
+        TraceView::API.trace(:cassandra, report_kvs, :get_range_batch) do
           get_range_batch_without_traceview(column_family, options)
         end
       end
@@ -164,7 +164,7 @@ module TraceView
         args = [column_family, index_clause] + columns_and_options
         report_kvs = extract_trace_details(:get_indexed_slices, column_family, nil, columns_and_options)
 
-        TraceView::API.trace('cassandra', report_kvs) do
+        TraceView::API.trace(:cassandra, report_kvs) do
           send :get_indexed_slices_without_traceview, *args
         end
       end
@@ -183,7 +183,7 @@ module TraceView
           TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
         end
 
-        TraceView::API.trace('cassandra', report_kvs) do
+        TraceView::API.trace(:cassandra, report_kvs) do
           create_index_without_traceview(keyspace, column_family, column_name, validation_class)
         end
       end
@@ -199,7 +199,7 @@ module TraceView
           TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
         end
 
-        TraceView::API.trace('cassandra', report_kvs) do
+        TraceView::API.trace(:cassandra, report_kvs) do
           drop_index_without_traceview(keyspace, column_family, column_name)
         end
       end
@@ -214,7 +214,7 @@ module TraceView
           TraceView.logger.debug "[traceview/debug] #{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" if TraceView::Config[:verbose]
         end
 
-        TraceView::API.trace('cassandra', report_kvs) do
+        TraceView::API.trace(:cassandra, report_kvs) do
           add_column_family_without_traceview(cf_def)
         end
       end
@@ -224,7 +224,7 @@ module TraceView
 
         report_kvs = extract_trace_details(:drop_column_family, column_family, nil, nil)
 
-        TraceView::API.trace('cassandra', report_kvs) do
+        TraceView::API.trace(:cassandra, report_kvs) do
           drop_column_family_without_traceview(column_family)
         end
       end
@@ -235,7 +235,7 @@ module TraceView
         report_kvs = extract_trace_details(:add_keyspace, nil, nil, nil)
         report_kvs[:Name] = ks_def.name rescue ''
 
-        TraceView::API.trace('cassandra', report_kvs) do
+        TraceView::API.trace(:cassandra, report_kvs) do
           add_keyspace_without_traceview(ks_def)
         end
       end
@@ -246,7 +246,7 @@ module TraceView
         report_kvs = extract_trace_details(:drop_keyspace, nil, nil, nil)
         report_kvs[:Name] = keyspace.to_s rescue ''
 
-        TraceView::API.trace('cassandra', report_kvs) do
+        TraceView::API.trace(:cassandra, report_kvs) do
           drop_keyspace_without_traceview(keyspace)
         end
       end

--- a/lib/traceview/inst/typhoeus.rb
+++ b/lib/traceview/inst/typhoeus.rb
@@ -12,7 +12,7 @@ module TraceView
       def run_with_traceview
         return run_without_traceview unless TraceView.tracing?
 
-        TraceView::API.log_entry('typhoeus')
+        TraceView::API.log_entry(:typhoeus)
 
         # Prepare X-Trace header handling
         blacklisted = TraceView::API.blacklisted?(url)
@@ -23,26 +23,26 @@ module TraceView
         response = run_without_traceview
 
         if response.code == 0
-          TraceView::API.log('typhoeus', 'error', { :ErrorClass => response.return_code,
-                                               :ErrorMsg => response.return_message })
+          TraceView::API.log(:typhoeus, :error, { :ErrorClass => response.return_code,
+                                                  :ErrorMsg => response.return_message })
         end
 
         kvs = {}
-        kvs['IsService'] = 1
+        kvs[:IsService] = 1
         kvs[:HTTPStatus] = response.code
-        kvs['Backtrace'] = TraceView::API.backtrace if TraceView::Config[:typhoeus][:collect_backtraces]
+        kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:typhoeus][:collect_backtraces]
 
         uri = URI(response.effective_url)
 
         # Conditionally log query params
         if TraceView::Config[:typhoeus][:log_args]
-          kvs['RemoteURL'] = uri.to_s
+          kvs[:RemoteURL] = uri.to_s
         else
-          kvs['RemoteURL'] = uri.to_s.split('?').first
+          kvs[:RemoteURL] = uri.to_s.split('?').first
         end
 
-        kvs['HTTPMethod'] = ::TraceView::Util.upcase(options[:method])
-        kvs['Blacklisted'] = true if blacklisted
+        kvs[:HTTPMethod] = ::TraceView::Util.upcase(options[:method])
+        kvs[:Blacklisted] = true if blacklisted
 
         # Re-attach net::http edge unless it's blacklisted or if we don't have a
         # valid X-Trace header
@@ -60,13 +60,13 @@ module TraceView
           end
         end
 
-        TraceView::API.log('typhoeus', 'info', kvs)
+        TraceView::API.log(:typhoeus, :info, kvs)
         response
       rescue => e
-        TraceView::API.log_exception('typhoeus', e)
+        TraceView::API.log_exception(:typhoeus, e)
         raise e
       ensure
-        TraceView::API.log_exit('typhoeus')
+        TraceView::API.log_exit(:typhoeus)
       end
     end
 

--- a/lib/traceview/inst/typhoeus.rb
+++ b/lib/traceview/inst/typhoeus.rb
@@ -84,7 +84,7 @@ module TraceView
         # FIXME: Until we figure out a strategy to deal with libcurl internal
         # threading and Ethon's use of easy handles, here we just do a simple
         # trace of the hydra run.
-        TraceView::API.trace("typhoeus_hydra", kvs) do
+        TraceView::API.trace(:typhoeus_hydra, kvs) do
           run_without_traceview
         end
       end

--- a/lib/traceview/method_profiling.rb
+++ b/lib/traceview/method_profiling.rb
@@ -5,7 +5,7 @@ module TraceView
       report_kvs[:Backtrace] = TraceView::API.backtrace(2) if opts[:backtrace]
       report_kvs[:Arguments] = args if opts[:arguments]
 
-      TraceView::API.log(nil, 'profile_entry', report_kvs)
+      TraceView::API.log(nil, :profile_entry, report_kvs)
 
       begin
         rv = self.send(method, *args, &block)
@@ -18,7 +18,7 @@ module TraceView
         report_kvs.delete(:Backtrace)
         report_kvs.delete(:Controller)
         report_kvs.delete(:Action)
-        TraceView::API.log(nil, 'profile_exit', report_kvs)
+        TraceView::API.log(nil, :profile_exit, report_kvs)
       end
     end
   end

--- a/lib/traceview/ruby.rb
+++ b/lib/traceview/ruby.rb
@@ -31,6 +31,6 @@ module TraceView
   end
 end
 
-if TraceView.loaded and !TraceView.framework?
+if TraceView.loaded && !TraceView.framework?
   ::TraceView::Ruby.load
 end

--- a/lib/traceview/util.rb
+++ b/lib/traceview/util.rb
@@ -42,8 +42,8 @@ module TraceView
             cls.private_method_defined?(without_traceview.to_sym)
 
             cls.class_eval do
-              alias_method without_traceview, "#{method}"
-              alias_method "#{method}", with_traceview
+              alias_method without_traceview, method.to_s
+              alias_method method.to_s, with_traceview
             end
           end
         else
@@ -71,8 +71,8 @@ module TraceView
 
           # Only alias if we haven't done so already
           unless cls.singleton_methods.include? without_traceview.to_sym
-            cls.singleton_class.send(:alias_method, without_traceview, "#{method}")
-            cls.singleton_class.send(:alias_method, "#{method}", with_traceview)
+            cls.singleton_class.send(:alias_method, without_traceview, method.to_s)
+            cls.singleton_class.send(:alias_method, method.to_s, with_traceview)
           end
         else TraceView.logger.warn "[traceview/loading] Couldn't properly instrument #{name}.  Partial traces may occur."
         end

--- a/test/profiling/legacy_method_profiling_test.rb
+++ b/test/profiling/legacy_method_profiling_test.rb
@@ -3,7 +3,7 @@
 
 require 'minitest_helper'
 
-describe "TraceViewMethodProfiling" do
+describe "LegacyTraceViewMethodProfiling" do
   before do
     clear_all_traces
     # Conditionally Undefine TestWorker

--- a/test/support/backcompat_test.rb
+++ b/test/support/backcompat_test.rb
@@ -30,8 +30,8 @@ describe "BackwardCompatibility" do
     TraceView::Config.sample_rate.must_equal 8e5
 
     Oboe::Config[:tracing_mode] = 'always'
-    Oboe::Config.tracing_mode.must_equal 'always'
-    TraceView::Config.tracing_mode.must_equal 'always'
+    Oboe::Config.tracing_mode.must_equal :always
+    TraceView::Config.tracing_mode.must_equal :always
 
     Oboe::Config[:sample_rate] = @sr
     Oboe::Config[:tracing_mode] = @tm

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -19,7 +19,7 @@ describe "TraceView::Config" do
     #
     # TraceView::Config[:verbose].must_equal false
 
-    TraceView::Config[:tracing_mode].must_equal "through"
+    TraceView::Config[:tracing_mode].must_equal :through
     TraceView::Config[:reporter_host].must_equal "127.0.0.1"
   end
 


### PR DESCRIPTION
We've historically used literal strings in the gem for event creation
such as 'Label', 'Layer', 'Entry', 'Exit', 'Info' etc..

Changing these to symbols lowers memory usage and improves performance in
comparison operations.

I've run a memory profiler against both the stock 3.8.0 gem and this branch
(attached) and these are the results.  The test was TraceView::API.start_trace
block run 100 times.  The code ran simple Dalli and Redis calls.

### Allocated Memory for TraceView gem

Before | After | Final Tweaks
------ | ---- | -----
546,964 | 371,924 |  349,844

* ~36% improvement

### Allocated objects for gem

Before | After | Final Tweaks
------ | ---- | -----
9536 | 5160 | 4608

* ~52% less allocated objects

Raw profiler results:
[traceview_stock.txt](https://github.com/appneta/ruby-traceview/files/235289/traceview_stock.txt)
[traceview_symbols.txt](https://github.com/appneta/ruby-traceview/files/235288/traceview_symbols.txt)
[traceview_final.txt](https://github.com/appneta/ruby-traceview/files/237257/traceview_final.txt)

```ruby
#!/usr/bin/env ruby

Bundler.require(:default)
require 'memory_profiler'

report = MemoryProfiler.report do
  TraceView::Config[:tracing_mode] = :always

  100.times do
    TraceView::API.start_trace('start_trace_profile') do
      @redis ||= Redis.new
      @dc = Dalli::Client.new

      @redis.setex("del_test", 60, "blah")
      @redis.exists("talking_heads")
      @redis.set("piano", Time.now)
      @dc.set('some_key', 1234)
      @dc.set('some_key2', 1234)
    end
  end
end

report.pretty_print
exit
```

Before merging this, we need to add tests to validate that the Tracing API accepts and handles correctly both strings and symbol arguments without issue.  I believe we already do test this to an extent but it should have full coverage.

- [x] Tests to validate API compatibility with both strings and symbols
- [x] Review TraceView.tracing_layer? symbol handling and storage
