### PR TITLE
alias_method_chain is deprecated; move to Module#prepend

### DIFF
--- a/lib/traceview/frameworks/rails/inst/action_controller.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller.rb
@@ -76,7 +76,11 @@ end
 if defined?(ActionController::Base) && TraceView::Config[:action_controller][:enabled]
   TraceView.logger.info '[traceview/loading] Instrumenting actioncontroller' if TraceView::Config[:verbose]
   require "traceview/frameworks/rails/inst/action_controller#{Rails::VERSION::MAJOR}"
-  ::TraceView::Util.send_include(::ActionController::Base, TraceView::Inst::ActionController)
+  if Rails::VERSION::MAJOR >= 5
+    ::ActionController::Base.send(:prepend, ::TraceView::Inst::ActionController)
+  else
+    ::TraceView::Util.send_include(::ActionController::Base, TraceView::Inst::ActionController)
+  end
 end
 
 # ActionController::API (Rails 5+)

--- a/lib/traceview/frameworks/rails/inst/action_controller.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller.rb
@@ -83,7 +83,7 @@ end
 if defined?(ActionController::API) && TraceView::Config[:action_controller_api][:enabled]
   TraceView.logger.info '[traceview/loading] Instrumenting actioncontroller api' if TraceView::Config[:verbose]
   require "traceview/frameworks/rails/inst/action_controller#{Rails::VERSION::MAJOR}_api"
-  ::TraceView::Util.send_include(::ActionController::API, TraceView::Inst::ActionControllerAPI)
+  ::ActionController::API.send(:prepend, ::TraceView::Inst::ActionControllerAPI)
 end
 
 # vim:set expandtab:tabstop=2

--- a/lib/traceview/frameworks/rails/inst/action_controller5_api.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller5_api.rb
@@ -7,19 +7,12 @@ module TraceView
     # ActionController
     #
     # This modules contains the instrumentation code specific
-    # to Rails v5
+    # to Rails v5.
     #
     module ActionControllerAPI
       include ::TraceView::Inst::RailsBase
 
-      def self.included(base)
-        base.class_eval do
-          alias_method_chain :process_action, :traceview
-          alias_method_chain :render, :traceview
-        end
-      end
-
-      def process_action_with_traceview(method_name, *args)
+      def process_action(method_name, *args)
         kvs = {
           :Controller   => self.class.name,
           :Action       => self.action_name,
@@ -27,13 +20,30 @@ module TraceView
         kvs[:Backtrace] = TraceView::API.backtrace if TraceView::Config[:action_controller_api][:collect_backtraces]
 
         TraceView::API.log_entry('rails-api', kvs)
-        process_action_without_traceview(method_name, *args)
+        super(method_name, *args)
 
       rescue Exception => e
         TraceView::API.log_exception(nil, e) if log_rails_error?(e)
         raise
       ensure
         TraceView::API.log_exit('rails-api')
+      end
+
+      #
+      # render
+      #
+      # Our render wrapper that just times and conditionally
+      # reports raised exceptions
+      #
+      def render(*args, &blk)
+        TraceView::API.log_entry('actionview')
+        super(*args, &blk)
+
+      rescue Exception => e
+        TraceView::API.log_exception(nil, e) if log_rails_error?(e)
+        raise
+      ensure
+        TraceView::API.log_exit('actionview')
       end
     end
   end


### PR DESCRIPTION
ActionController alias_method_chain deprecation (use Module#prepend)

Right now we get a deprecation warning:
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from block in included at /home/pglombardo/Projects/ruby-traceview/lib/traceview/frameworks/rails/inst/action_controller5.rb:17)

We need to update the Rails 5 instrumentation to use Module#prepend instead.